### PR TITLE
cors headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM node:16.8.0
 COPY nodejs-server /app
 WORKDIR /app
 RUN npm install
+RUN cp mods/express.app.config.js /app/node_modules/oas3-tools/dist/middleware/express.app.config.js
 CMD npm start

--- a/nodejs-server/mods/express.app.config.js
+++ b/nodejs-server/mods/express.app.config.js
@@ -1,0 +1,75 @@
+'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ExpressAppConfig = void 0;
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const bodyParser = require("body-parser");
+const swagger_ui_1 = require("./swagger.ui");
+const swagger_router_1 = require("./swagger.router");
+const swagger_parameters_1 = require("./swagger.parameters");
+const logger = require("morgan");
+const fs = require("fs");
+const jsyaml = require("js-yaml");
+const OpenApiValidator = require("express-openapi-validator");
+const cors = require("cors");
+class ExpressAppConfig {
+    constructor(definitionPath, appOptions) {
+        this.definitionPath = definitionPath;
+        this.routingOptions = appOptions.routing;
+        this.setOpenApiValidatorOptions(definitionPath, appOptions);
+        this.app = express();
+        this.app.use(cors());
+        const spec = fs.readFileSync(definitionPath, 'utf8');
+        const swaggerDoc = jsyaml.safeLoad(spec);
+        this.app.use(bodyParser.urlencoded());
+        this.app.use(bodyParser.text());
+        this.app.use(bodyParser.json());
+        this.app.use(this.configureLogger(appOptions.logging));
+        this.app.use(express.json());
+        this.app.use(express.urlencoded({ extended: false }));
+        this.app.use(cookieParser());
+        const swaggerUi = new swagger_ui_1.SwaggerUI(swaggerDoc, appOptions.swaggerUI);
+        this.app.use(swaggerUi.serveStaticContent());
+        this.app.use(OpenApiValidator.middleware(this.openApiValidatorOptions));
+        this.app.use(new swagger_parameters_1.SwaggerParameters().checkParameters());
+        this.app.use(new swagger_router_1.SwaggerRouter().initialize(this.routingOptions));
+        this.app.use(this.errorHandler);
+    }
+    setOpenApiValidatorOptions(definitionPath, appOptions) {
+        //If no options or no openApiValidator Options given, create empty options with api definition path
+        if (!appOptions || !appOptions.openApiValidator) {
+            this.openApiValidatorOptions = { apiSpec: definitionPath };
+            return;
+        }
+        // use the given options
+        this.openApiValidatorOptions = appOptions.openApiValidator;
+        // Override apiSpec with definition Path to keep the prior behavior
+        this.openApiValidatorOptions.apiSpec = definitionPath;
+    }
+    configureLogger(loggerOptions) {
+        let format = 'dev';
+        let options = {};
+        if (loggerOptions != undefined) {
+            if (loggerOptions.format != undefined
+                && typeof loggerOptions.format === 'string') {
+                format = loggerOptions.format;
+            }
+            if (loggerOptions.errorLimit != undefined
+                && (typeof loggerOptions.errorLimit === 'string' || typeof loggerOptions.errorLimit === 'number')) {
+                options['skip'] = function (req, res) { return res.statusCode < parseInt(loggerOptions.errorLimit); };
+            }
+        }
+        return logger(format, options);
+    }
+    errorHandler(error, request, response, next) {
+        response.status(error.status || 500).json({
+            message: error.message,
+            errors: error.errors,
+        });
+    }
+    getApp() {
+        return this.app;
+    }
+}
+exports.ExpressAppConfig = ExpressAppConfig;
+//# sourceMappingURL=express.app.config.js.map

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "connect": "^3.2.0",
+    "cors": "^2.8.5",
     "debug": "3.1.0",
     "js-yaml": "^3.3.0",
     "moment": "^2.24.0",


### PR DESCRIPTION
Manipulates the oa3 package to staple cors headers onto every response. Not the most beautiful code; some things to address in future:

 - Keep an eye out for when this becomes an officially supported option instead of a kludge
 - Is `*` the best choice? Limiting to localhost and colorado.edu would be tighter and not block non-browser apps, might be a good tradeoff.