### PR TITLE
colons in date-time

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -39,6 +39,7 @@ paths:
         required: true
         style: form
         explode: true
+        allowReserved: true
         schema:
           type: string
           format: date-time
@@ -237,6 +238,7 @@ components:
       required: true
       style: form
       explode: true
+      allowReserved: true
       schema:
         type: string
         format: date-time

--- a/spec.yaml
+++ b/spec.yaml
@@ -139,6 +139,7 @@ components:
       schema:
         type: string
         format: date-time
+      allowReserved: true
       example: '2010-01-01T00:00:00Z'
     arID:
       in: query


### PR DESCRIPTION
Previous implementation allowed explicit colons in date-time objects in query string for ar routes; the PR restores that behavior.