### PR TITLE
ID list corrections

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1239,18 +1239,6 @@ paths:
         schema:
           type: string
           example: "[[-74.2126,40.5221],[-73.6798,40.9135]]"
-      - name: ids
-        in: query
-        description: List of profile IDs
-        required: false
-        style: form
-        explode: false
-        allowReserved: true
-        schema:
-          type: array
-          example: "4902911_0,4902911_97"
-          items:
-            type: string
       - name: platforms
         in: query
         description: List of platform IDs

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -13,8 +13,8 @@ module.exports.profile = function profile (req, res, next, startDate, endDate, p
     });
 };
 
-module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, ids, platforms, presRange, coreMeasurements, bgcMeasurements) {
-  Profiles.profileList(startDate, endDate, polygon, box, ids, platforms, presRange, coreMeasurements, bgcMeasurements)
+module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, platforms, presRange, coreMeasurements, bgcMeasurements) {
+  Profiles.profileList(startDate, endDate, polygon, box, platforms, presRange, coreMeasurements, bgcMeasurements)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/index.js
+++ b/nodejs-server/index.js
@@ -25,7 +25,7 @@ http.createServer(app).listen(serverPort, function () {
 
 // mongodb config and connection //////////////////
 mongoose.Promise = global.Promise;
-const mongoDB = "mongodb://database/argo" // EV this later
+const mongoDB = "mongodb://database/goship" // EV this later
 const mongooseOptions = {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/nodejs-server/index.js
+++ b/nodejs-server/index.js
@@ -25,7 +25,7 @@ http.createServer(app).listen(serverPort, function () {
 
 // mongodb config and connection //////////////////
 mongoose.Promise = global.Promise;
-const mongoDB = "mongodb://database/goship" // EV this later
+const mongoDB = "mongodb://database/argo" // EV this later
 const mongooseOptions = {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -147,14 +147,13 @@ exports.profile = function(startDate,endDate,polygon,box,ids,platforms,presRange
  * endDate Date date-time formatted string indicating the end of a time period (optional)
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * box String box described as [[lower left lon, lower left lat], [upper right lon, upper right lat]] (optional)
- * ids List List of profile IDs (optional)
  * platforms List List of platform IDs (optional)
  * presRange List Pressure range (optional)
  * coreMeasurements List Keys of core measurements to include (optional)
  * bgcMeasurements List Keys of BGC measurements to include (optional)
  * returns List
  **/
-exports.profileList = function(startDate,endDate,polygon,box,ids,platforms,presRange,coreMeasurements,bgcMeasurements) {
+exports.profileList = function(startDate,endDate,polygon,box,platforms,presRange,coreMeasurements,bgcMeasurements) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -101,14 +101,13 @@ exports.profileList = function(startDate,endDate,polygon,box,platforms,presRange
     if(endDate) endDate = new Date(endDate);
     if (
       (!endDate || !startDate || (endDate - startDate)/3600000/24 > 90) &&
-      (!ids || ids.length >100) &&
       (!platforms || platforms.length>1)) {
 
-      reject({"code": 400, "message": "Please request <= 90 days of data at a time, OR a single platform, OR at most 100 profile IDs."});
+      reject({"code": 400, "message": "Please request <= 90 days of data at a time, OR a single platform."});
       return; 
     } 
 
-    let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,ids,platforms,presRange)
+    let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,null,platforms,presRange)
 
     if('code' in aggPipeline){
       reject(aggPipeline);

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -100,6 +100,14 @@ exports.profileList = function(startDate,endDate,polygon,box,ids,platforms,presR
   return new Promise(function(resolve, reject) {
     if(startDate) startDate = new Date(startDate);
     if(endDate) endDate = new Date(endDate);
+    if (
+      (!endDate || !startDate || (endDate - startDate)/3600000/24 > 90) &&
+      (!ids || ids.length >100) &&
+      (!platforms || platforms.length>1)) {
+
+      reject({"code": 400, "message": "Please request <= 90 days of data at a time, OR a single platform, OR at most 100 profile IDs."});
+      return; 
+    } 
 
     let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,ids,platforms,presRange)
 

--- a/spec.json
+++ b/spec.json
@@ -844,9 +844,6 @@
                   "$ref": "#/components/parameters/box"
                },
                {
-                  "$ref": "#/components/parameters/idList"
-               },
-               {
                   "$ref": "#/components/parameters/platformList"
                },
                {

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -75,28 +75,28 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles/listID", function () {
       it("lists the IDs of any profile with BGC data", async function () {
-        const response = await request.get("/profiles/listID?bgcMeasurements=all");
+        const response = await request.get("/profiles/listID?startDate=2019-07-04T03:03:00Z&endDate=2019-09-04T03:03:00Z&bgcMeasurements=all");
         expect(response.body[0]).to.eql('337566314.951_213')  
       });
     }); 
 
     describe("GET /profiles/listID", function () {
       it("lists the IDs of any profile with a core salinity measurement", async function () {
-        const response = await request.get("/profiles/listID?coreMeasurements=psal");
-        expect(response.body).to.have.members([ '4902911_0', '4902911_10', '4902911_11', '337566314.951_213' ])
+        const response = await request.get("/profiles/listID?startDate=2017-04-23T03:40:19Z&endDate=2017-07-06T18:50:38.002Z&coreMeasurements=psal");
+        expect(response.body).to.have.members([ '4902911_0', '4902911_10', '4902911_11' ])
       });
     }); 
 
     describe("GET /profiles/listID", function () {
       it("lists the IDs of any profile with BGC data or a core salinity measurement", async function () {
-        const response = await request.get("/profiles/listID?coreMeasurements=psal&bgcMeasurements=all");
-        expect(response.body).to.have.members([ '4902911_0', '4902911_10', '4902911_11', '337566314.951_213' ])
+        const response = await request.get("/profiles/listID?startDate=2019-07-04T03:03:00Z&endDate=2019-09-04T03:03:00Z&coreMeasurements=psal&bgcMeasurements=all");
+        expect(response.body).to.have.members(['337566314.951_213'])
       });
     });
 
     describe("GET /profiles/listID", function () {
       it("fails to find any dissolved oxygen in BGC measurements", async function () {
-        const response = await request.get("/profiles/listID?&bgcMeasurements=doxy");
+        const response = await request.get("/profiles/listID?startDate=2019-07-04T03:03:00Z&endDate=2019-09-04T03:03:00Z&bgcMeasurements=doxy");
         expect(response.status).to.eql(404);
       });
     });        


### PR DESCRIPTION
 - Even just returning IDs ended up being pretty slow for the goship demo. Reimpose same search limits as /profiles.
 - Doesn't actually make sense to search for IDs by ID; remove this filter for /profiles/listID