### PR TITLE
allow overlap between different BGC lists

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -2054,7 +2054,7 @@ components:
       - psal
       - all
     bgcMeasurement:
-      oneOf:
+      anyOf:
       - $ref: '#/components/schemas/argoBgcMeasurement'
       - $ref: '#/components/schemas/goshipBgcMeasurement'
     argoBgcMeasurement:
@@ -2115,7 +2115,7 @@ components:
     goshipBgcMeasurement: {}
     bgcMeasurementKey:
       type: string
-      oneOf:
+      anyOf:
       - $ref: '#/components/schemas/argoBgcMeasurementKey'
       - $ref: '#/components/schemas/goshipBgcMeasurementKey'
     argoBgcMeasurementKey:

--- a/spec.json
+++ b/spec.json
@@ -1673,7 +1673,7 @@
             ]
          },
          "bgcMeasurement": {
-            "oneOf": [
+            "anyOf": [
                {
                   "$ref": "#/components/schemas/argoBgcMeasurement"
                },
@@ -1812,7 +1812,7 @@
          },
          "bgcMeasurementKey":{
             "type": "string",
-            "oneOf": [
+            "anyOf": [
                {
                   "$ref": "#/components/schemas/argoBgcMeasurementKey"
                },


### PR DESCRIPTION
variables like `pres` can appear in more than one, so the composite schema must be `anyOf`, not `oneOf`, which is an xor.