### PR TITLE
atmo river route standardization

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -38,18 +38,18 @@ tags:
 - name: dacs
   description: Summary and metadata for data assembly centers represented in the dataset
 paths:
-  /arShapes/findByDate:
+  /ar:
     get:
       tags:
       - ar
-      summary: shapes representing atmospheric rivers at a given date-time
-      operationId: findARbyDate
+      summary: Find and filter atmo river shapes.
+      operationId: findAR
       parameters:
       - name: date
         in: query
         description: three hour increments starting at 2004-01-01T00:00:00 and ending
           at 2017-04-02T03:00:00
-        required: true
+        required: false
         style: form
         explode: true
         allowReserved: true
@@ -57,80 +57,15 @@ paths:
           type: string
           format: date-time
           example: 2010-01-01T00:00:00Z
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/arShapeSchema'
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-        "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-        "500":
-          description: Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-      x-swagger-router-controller: Ar
-  /arShapes/findByID:
-    get:
-      tags:
-      - ar
-      summary: shapes representing atmospheric rivers with a given ID
-      operationId: findARbyID
-      parameters:
       - name: _id
         in: query
         description: ID of an atmospheric river object
-        required: true
+        required: false
         style: form
         explode: true
         schema:
           type: string
           example: 1_262992
-      responses:
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/arShapeSchema'
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-        "404":
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-        "500":
-          description: Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/errorResponse'
-      x-swagger-router-controller: Ar
-  /arShapes:
-    get:
-      tags:
-      - ar
-      summary: one instance of a shape representing an atmospheric river
-      operationId: findOneAR
       responses:
         "200":
           description: OK
@@ -2368,7 +2303,7 @@ components:
       in: query
       description: three hour increments starting at 2004-01-01T00:00:00 and ending
         at 2017-04-02T03:00:00
-      required: true
+      required: false
       style: form
       explode: true
       allowReserved: true
@@ -2380,7 +2315,7 @@ components:
       name: _id
       in: query
       description: ID of an atmospheric river object
-      required: true
+      required: false
       style: form
       explode: true
       schema:

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -72,7 +72,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/arShapeSchema'
+                type: array
+                items:
+                  $ref: '#/components/schemas/arShapeSchema'
+                x-content-type: application/json
         "400":
           description: Bad Request
           content:

--- a/nodejs-server/controllers/Ar.js
+++ b/nodejs-server/controllers/Ar.js
@@ -3,28 +3,8 @@
 var utils = require('../utils/writer.js');
 var Ar = require('../service/ArService');
 
-module.exports.findARbyDate = function findARbyDate (req, res, next, date) {
-  Ar.findARbyDate(date)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    })
-    .catch(function (response) {
-      utils.writeJson(res, response);
-    });
-};
-
-module.exports.findARbyID = function findARbyID (req, res, next, _id) {
-  Ar.findARbyID(_id)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    })
-    .catch(function (response) {
-      utils.writeJson(res, response);
-    });
-};
-
-module.exports.findOneAR = function findOneAR (req, res, next) {
-  Ar.findOneAR()
+module.exports.findAR = function findAR (req, res, next, date, _id) {
+  Ar.findAR(date, _id)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/ArService.js
+++ b/nodejs-server/service/ArService.js
@@ -2,67 +2,13 @@
 
 
 /**
- * shapes representing atmospheric rivers at a given date-time
+ * Find and filter atmo river shapes.
  *
- * date Date three hour increments starting at 2004-01-01T00:00:00 and ending at 2017-04-02T03:00:00
+ * date Date three hour increments starting at 2004-01-01T00:00:00 and ending at 2017-04-02T03:00:00 (optional)
+ * _id String ID of an atmospheric river object (optional)
  * returns arShapeSchema
  **/
-exports.findARbyDate = function(date) {
-  return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = {
-  "date" : "2000-01-23T04:56:07.000+00:00",
-  "date_formateed" : "2000-01-23",
-  "shapeId" : 0,
-  "geoLocation" : {
-    "coordinates" : [ [ 6.027456183070403, 6.027456183070403 ], [ 6.027456183070403, 6.027456183070403 ] ],
-    "type" : "type"
-  },
-  "_id" : "_id"
-};
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
-  });
-}
-
-
-/**
- * shapes representing atmospheric rivers with a given ID
- *
- * _id String ID of an atmospheric river object
- * returns arShapeSchema
- **/
-exports.findARbyID = function(_id) {
-  return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = {
-  "date" : "2000-01-23T04:56:07.000+00:00",
-  "date_formateed" : "2000-01-23",
-  "shapeId" : 0,
-  "geoLocation" : {
-    "coordinates" : [ [ 6.027456183070403, 6.027456183070403 ], [ 6.027456183070403, 6.027456183070403 ] ],
-    "type" : "type"
-  },
-  "_id" : "_id"
-};
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
-  });
-}
-
-
-/**
- * one instance of a shape representing an atmospheric river
- *
- * returns arShapeSchema
- **/
-exports.findOneAR = function() {
+exports.findAR = function(date,_id) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = {

--- a/nodejs-server/service/ArService.js
+++ b/nodejs-server/service/ArService.js
@@ -6,12 +6,12 @@
  *
  * date Date three hour increments starting at 2004-01-01T00:00:00 and ending at 2017-04-02T03:00:00 (optional)
  * _id String ID of an atmospheric river object (optional)
- * returns arShapeSchema
+ * returns List
  **/
 exports.findAR = function(date,_id) {
   return new Promise(function(resolve, reject) {
     var examples = {};
-    examples['application/json'] = {
+    examples['application/json'] = [ {
   "date" : "2000-01-23T04:56:07.000+00:00",
   "date_formateed" : "2000-01-23",
   "shapeId" : 0,
@@ -20,7 +20,16 @@ exports.findAR = function(date,_id) {
     "type" : "type"
   },
   "_id" : "_id"
-};
+}, {
+  "date" : "2000-01-23T04:56:07.000+00:00",
+  "date_formateed" : "2000-01-23",
+  "shapeId" : 0,
+  "geoLocation" : {
+    "coordinates" : [ [ 6.027456183070403, 6.027456183070403 ], [ 6.027456183070403, 6.027456183070403 ] ],
+    "type" : "type"
+  },
+  "_id" : "_id"
+} ];
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {

--- a/spec.json
+++ b/spec.json
@@ -85,7 +85,10 @@
                   "content": {
                      "application/json": {
                         "schema": {
-                           "$ref": "#/components/schemas/arShapeSchema"
+                           "type": "array",
+                           "items": {
+                              "$ref": "#/components/schemas/arShapeSchema"
+                           }
                         }
                      }
                   }

--- a/spec.json
+++ b/spec.json
@@ -64,83 +64,21 @@
       }
    ],
    "paths": {
-      "/arShapes/findByDate": {
+      "/ar": {
          "get": {
             "tags": [
                "ar"
             ],
-            "summary": "shapes representing atmospheric rivers at a given date-time",
-            "operationId": "findARbyDate",
+            "summary": "Find and filter atmo river shapes.",
+            "operationId": "findAR",   
             "parameters": [
                {
                   "$ref": "#/components/parameters/arDate"
-               }
-            ],
-            "responses": {
-               "200": {
-                  "description": "OK",
-                  "content": {
-                     "application/json": {
-                        "schema": {
-                           "$ref": "#/components/schemas/arShapeSchema"
-                        }
-                     }
-                  }
                },
-               "400": {
-                  "$ref": "#/components/responses/badRequest"
-               },
-               "404": {
-                  "$ref": "#/components/responses/notFound"
-               },
-               "500": {
-                  "$ref": "#/components/responses/serverError"
-               }
-            }
-         }
-      },
-      "/arShapes/findByID": {
-         "get": {
-            "tags": [
-               "ar"
-            ],
-            "summary": "shapes representing atmospheric rivers with a given ID",
-            "operationId": "findARbyID",
-            "parameters": [
                {
                   "$ref": "#/components/parameters/arID"
                }
             ],
-            "responses": {
-               "200": {
-                  "description": "OK",
-                  "content": {
-                     "application/json": {
-                        "schema": {
-                           "$ref": "#/components/schemas/arShapeSchema"
-                        }
-                     }
-                  }
-               },
-               "400": {
-                  "$ref": "#/components/responses/badRequest"
-               },
-               "404": {
-                  "$ref": "#/components/responses/notFound"
-               },
-               "500": {
-                  "$ref": "#/components/responses/serverError"
-               }
-            }
-         }
-      },
-      "/arShapes": {
-         "get": {
-            "tags": [
-               "ar"
-            ],
-            "summary": "one instance of a shape representing an atmospheric river",
-            "operationId": "findOneAR",
             "responses": {
                "200": {
                   "description": "OK",
@@ -1982,7 +1920,7 @@
          "arDate": {
             "in": "query",
             "name": "date",
-            "required": true,
+            "required": false,
             "description": "three hour increments starting at 2004-01-01T00:00:00 and ending at 2017-04-02T03:00:00",
             "allowReserved": true,
             "schema": {
@@ -1994,7 +1932,7 @@
          "arID": {
             "in": "query",
             "name": "_id",
-            "required": true,
+            "required": false,
             "description": "ID of an atmospheric river object",
             "schema": {
                "type": "string",


### PR DESCRIPTION
Rewrites the AR routes to follow the logic of the new profiles routes: the route specifies the schema returned, and filters are captured in the query string.