### PR TITLE
special redis conf required on CU OKD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 script:
   - docker network create travis
   - docker container run -d --network travis --name database argovis/testdb:0.1
-  - docker container run -d --network travis --name redis redis:6.2.6
+  - docker container run -d --network travis --name redis argovis/redis:6.2.6
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .
   - docker container run -d --network travis --name api argovis/api:test


### PR DESCRIPTION
It appears at least by default, CU OKD doesn't allow writes to container filesystems, which messes with Redis' background backups. We don't really need these, so turn them off via the custom conf here: https://github.com/argovis/argovis_redis