### PR TITLE
performance improvements

### DIFF
--- a/nodejs-server/index.js
+++ b/nodejs-server/index.js
@@ -40,7 +40,8 @@ const mongooseOptions = {
   useNewUrlParser: true,
   useUnifiedTopology: true,
   keepAlive: 1,
-  connectTimeoutMS: 30000
+  connectTimeoutMS: 30000,
+  maxPoolSize: 2
 };
 
 mongoose.connect(mongoDB, mongooseOptions)

--- a/nodejs-server/utils/writer.js
+++ b/nodejs-server/utils/writer.js
@@ -36,7 +36,7 @@ var writeJson = exports.writeJson = function(response, arg1, arg2) {
     code = 200;
   }
   if(typeof payload === 'object') {
-    payload = JSON.stringify(payload, null, 2);
+    payload = JSON.stringify(payload, null, null);
   }
   response.writeHead(code, {'Content-Type': 'application/json'});
   response.end(payload);


### PR DESCRIPTION
 - Early performance tuning indicates that the default `maxPoolSize` of 100 completely swamps our small deployment. Turning this way down to something order-of-magnitude comparable to the number of CPUs allocated to mongo improved response speeds of large requests by two orders of magnitude.
 - Of course, we shouldn't be transmitting all that whitespace the default API boilerplate adds; removed here.