### PR TITLE
Proximity search on /profiles

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -861,6 +861,29 @@ paths:
         schema:
           type: string
           example: "[[-74.2126,40.5221],[-73.6798,40.9135]]"
+      - name: center
+        in: query
+        description: center to measure max radius from
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "10,20.1"
+          items:
+            maxItems: 2
+            minItems: 2
+            type: number
+      - name: radius
+        in: query
+        description: km from centerpoint
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: number
+          example: 0
       - name: ids
         in: query
         description: List of profile IDs
@@ -2434,6 +2457,31 @@ components:
       schema:
         type: string
         example: "[[-74.2126,40.5221],[-73.6798,40.9135]]"
+    center:
+      name: center
+      in: query
+      description: center to measure max radius from
+      required: false
+      style: form
+      explode: false
+      allowReserved: true
+      schema:
+        type: array
+        example: "10,20.1"
+        items:
+          maxItems: 2
+          minItems: 2
+          type: number
+    radius:
+      name: radius
+      in: query
+      description: km from centerpoint
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: number
+        example: 0
     coreMeasurements:
       name: coreMeasurements
       in: query

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1026,6 +1026,29 @@ paths:
         schema:
           type: string
           example: "[[-74.2126,40.5221],[-73.6798,40.9135]]"
+      - name: center
+        in: query
+        description: center to measure max radius from
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "10,20.1"
+          items:
+            maxItems: 2
+            minItems: 2
+            type: number
+      - name: radius
+        in: query
+        description: km from centerpoint
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: number
+          example: 0
       - name: platforms
         in: query
         description: List of platform IDs

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
 
-module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, ids, platforms, presRange, coreMeasurements, bgcMeasurements) {
-  Profiles.profile(startDate, endDate, polygon, box, ids, platforms, presRange, coreMeasurements, bgcMeasurements)
+module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, center, radius, ids, platforms, presRange, coreMeasurements, bgcMeasurements) {
+  Profiles.profile(startDate, endDate, polygon, box, center, radius, ids, platforms, presRange, coreMeasurements, bgcMeasurements)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -13,8 +13,8 @@ module.exports.profile = function profile (req, res, next, startDate, endDate, p
     });
 };
 
-module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, platforms, presRange, coreMeasurements, bgcMeasurements) {
-  Profiles.profileList(startDate, endDate, polygon, box, platforms, presRange, coreMeasurements, bgcMeasurements)
+module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, center, radius, platforms, presRange, coreMeasurements, bgcMeasurements) {
+  Profiles.profileList(startDate, endDate, polygon, box, center, radius, platforms, presRange, coreMeasurements, bgcMeasurements)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -8,6 +8,8 @@
  * endDate Date date-time formatted string indicating the end of a time period (optional)
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * box String box described as [[lower left lon, lower left lat], [upper right lon, upper right lat]] (optional)
+ * center List center to measure max radius from (optional)
+ * radius BigDecimal km from centerpoint (optional)
  * ids List List of profile IDs (optional)
  * platforms List List of platform IDs (optional)
  * presRange List Pressure range (optional)
@@ -15,7 +17,7 @@
  * bgcMeasurements List Keys of BGC measurements to include (optional)
  * returns List
  **/
-exports.profile = function(startDate,endDate,polygon,box,ids,platforms,presRange,coreMeasurements,bgcMeasurements) {
+exports.profile = function(startDate,endDate,polygon,box,center,radius,ids,platforms,presRange,coreMeasurements,bgcMeasurements) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -149,13 +149,15 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,ids,platf
  * endDate Date date-time formatted string indicating the end of a time period (optional)
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * box String box described as [[lower left lon, lower left lat], [upper right lon, upper right lat]] (optional)
+ * center List center to measure max radius from (optional)
+ * radius BigDecimal km from centerpoint (optional)
  * platforms List List of platform IDs (optional)
  * presRange List Pressure range (optional)
  * coreMeasurements List Keys of core measurements to include (optional)
  * bgcMeasurements List Keys of BGC measurements to include (optional)
  * returns List
  **/
-exports.profileList = function(startDate,endDate,polygon,box,platforms,presRange,coreMeasurements,bgcMeasurements) {
+exports.profileList = function(startDate,endDate,polygon,box,center,radius,platforms,presRange,coreMeasurements,bgcMeasurements) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -31,7 +31,17 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,ids,platf
       return; 
     } 
 
-    let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,ids,platforms,presRange)
+    if((center && box) || (center && polygon) || (box && polygon)){
+      reject({"code": 400, "message": "Please request only one of box, polygon or center."});
+      return; 
+    }
+
+    if((center && !radius) || (!center && radius)){
+      reject({"code": 400, "message": "Please specify both radius and center to filter for profiles less than <radius> km from <center>."});
+      return; 
+    }
+
+    let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,radius,center,ids,platforms,presRange)
 
     if('code' in aggPipeline){
       reject(aggPipeline);

--- a/spec.json
+++ b/spec.json
@@ -642,6 +642,12 @@
                {
                   "$ref": "#/components/parameters/box"
                },
+{
+                  "$ref": "#/components/parameters/center"
+               },
+               {
+                  "$ref": "#/components/parameters/radius"
+               },
                {
                   "$ref": "#/components/parameters/platformList"
                },

--- a/spec.json
+++ b/spec.json
@@ -575,6 +575,12 @@
                   "$ref": "#/components/parameters/box"
                },
                {
+                  "$ref": "#/components/parameters/center"
+               },
+               {
+                  "$ref": "#/components/parameters/radius"
+               },
+               {
                   "$ref": "#/components/parameters/idList"
                },
                {
@@ -2071,6 +2077,32 @@
             "schema": {
                "type": "string",
                "example": "[[-74.2126,40.5221],[-73.6798,40.9135]]"
+            }
+         },
+         "center": {
+            "in": "query",
+            "name": "center",
+            "description": "center to measure max radius from",
+            "style": "form",
+            "explode": false,
+            "allowReserved": true,
+            "schema": {
+               "type": "array",
+               "items": {
+                  "type": "number",
+                  "minItems": 2,
+                  "maxItems": 2
+               },
+               "example": "10,20.1"
+            }
+         },
+         "radius": {
+            "in": "query",
+            "name": "radius",
+            "description": "km from centerpoint",
+            "schema": {
+               "type": "number",
+               "example": 0
             }
          },
          "coreMeasurements": {

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -66,6 +66,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /profiles", function () {
+      it("should find 3 profiles within a 100 km of this point", async function () {
+        const response = await request.get("/profiles?startDate=2017-04-24T00:00:00Z&endDate=2017-07-06T00:00:00Z&center=-74.79661,34.92019&radius=100").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(3)
+      });
+    });
+
     describe("GET /profiles/overview", function () {
       it("summarizes profile collection", async function () {
         const response = await request.get("/profiles/overview").set({'x-argokey': 'developer'});


### PR DESCRIPTION
As an alternative to `polygon` and `box` regional searches, enable `center` and `radius` combination for a proximity search. Could be useful for colocation work.