### PR TITLE
Steradian weighted sums

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -3,5 +3,6 @@ WORKDIR /tests
 COPY tests/package.json .
 RUN npm install
 COPY tests .
+COPY nodejs-server/service/helpers.js tests/helpers.js
 COPY spec.json .
 CMD npm test

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -178,13 +178,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Covar
-  /covarIntegral:
+  /covarSum:
     get:
       tags:
       - covar
-      summary: Integral of probability distribution field over a region for a float
-        starting at point lat-lon after forcastDays.
-      operationId: integralCovar
+      summary: Sum of probability distribution field over a region for a float starting
+        at point lat-lon after forcastDays.
+      operationId: sumCovar
       parameters:
       - name: lat
         in: query
@@ -2251,13 +2251,13 @@ components:
           type: string
     inline_response_200:
       required:
-      - integral
+      - sum
       type: object
       properties:
-        integral:
+        sum:
           type: integer
       example:
-        integral: 0
+        sum: 0
     platform:
       anyOf:
       - type: string

--- a/nodejs-server/controllers/Covar.js
+++ b/nodejs-server/controllers/Covar.js
@@ -13,8 +13,8 @@ module.exports.findCovar = function findCovar (req, res, next, lat, lon, forcast
     });
 };
 
-module.exports.integralCovar = function integralCovar (req, res, next, lat, lon, forcastDays, polygon) {
-  Covar.integralCovar(lat, lon, forcastDays, polygon)
+module.exports.sumCovar = function sumCovar (req, res, next, lat, lon, forcastDays, polygon) {
+  Covar.sumCovar(lat, lon, forcastDays, polygon)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Covar.js
+++ b/nodejs-server/controllers/Covar.js
@@ -16,8 +16,8 @@ module.exports.findCovar = function findCovar (req, res, next, lat, lon, forcast
     });
 };
 
-module.exports.integralCovar = function integralCovar (req, res, next, lat, lon, forcastDays, polygon) {
-  Covar.integralCovar(lat, lon, forcastDays, polygon)
+module.exports.sumCovar = function sumCovar (req, res, next, lat, lon, forcastDays, polygon) {
+  Covar.sumCovar(lat, lon, forcastDays, polygon)
     .then(function (response) {
       utils.writeJson(res, response, 200);
     },

--- a/nodejs-server/service/CovarService.js
+++ b/nodejs-server/service/CovarService.js
@@ -43,7 +43,7 @@ exports.findCovar = function(lat,lon,forcastDays) {
 
 
 /**
- * Integral of probability distribution field over a region for a float starting at point lat-lon after forcastDays.
+ * Sum of probability distribution field over a region for a float starting at point lat-lon after forcastDays.
  *
  * lat BigDecimal latitude (degrees) of Argo float location
  * lon BigDecimal longitude (degrees) of Argo float location
@@ -51,11 +51,11 @@ exports.findCovar = function(lat,lon,forcastDays) {
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * returns inline_response_200
  **/
-exports.integralCovar = function(lat,lon,forcastDays,polygon) {
+exports.sumCovar = function(lat,lon,forcastDays,polygon) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = {
-  "integral" : 0
+  "sum" : 0
 };
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);

--- a/nodejs-server/service/CovarService.js
+++ b/nodejs-server/service/CovarService.js
@@ -43,7 +43,7 @@ exports.findCovar = function(lat,lon,forcastDays) {
 
 
 /**
- * Integral of probability distribution field over a region for a float starting at point lat-lon after forcastDays.
+ * Sum of probability distribution field over a region for a float starting at point lat-lon after forcastDays.
  *
  * lat BigDecimal latitude (degrees) of Argo float location
  * lon BigDecimal longitude (degrees) of Argo float location
@@ -51,7 +51,7 @@ exports.findCovar = function(lat,lon,forcastDays) {
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * returns inline_response_200
  **/
-exports.integralCovar = function(lat,lon,forcastDays,polygon) {
+exports.sumCovar = function(lat,lon,forcastDays,polygon) {
   return new Promise(function(resolve, reject) {
     var point = {"type": "Point", "coordinates": [lon,lat]};
     if (!GJV.valid(point) || !GJV.isPoint(point)){
@@ -82,7 +82,7 @@ exports.integralCovar = function(lat,lon,forcastDays,polygon) {
             "coordinates": [JSON.parse(polygon)]
         }
         let p = covars.features.map(x => x.properties.Probability*(pointInPolygon(x.geometry, polygon) ? 1:0)).reduce((a, b) => a + b, 0)
-        resolve({"integral":p});
+        resolve({"sum":p});
     })
 
   });

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -15,3 +15,24 @@ module.exports.queryCallback = function(postprocess, resolve, reject, err, data)
     if(postprocess) resolve(postprocess(data))
     else resolve(data);
 }
+
+module.exports.steradians = function(lons, lats){
+    // lons: [<low lon, high lon>] in degrees
+    // lats: [<low lat, high lat>] in degrees
+    // returns the steradians bounded by the provided lats, lons
+
+    return Math.abs((lons[1]/180*Math.PI - lons[0]/180*Math.PI)*(-Math.cos(Math.PI/2 - lats[1]/180*Math.PI) + Math.cos(Math.PI/2 - lats[0]/180*Math.PI)))
+}
+
+module.exports.geoWeightedSum = function(terms){
+    // terms: array of objects {value: <scalar value>, lons: [<low lon, high lon>], lats: [<low lat>, <high lat>] }
+    // returns the sum of all `value` keys, multiplied by the steradians bounded by the box defined by the lats and lons (in degrees) associated with each term.
+
+    sum = 0
+    for(i=0; i<terms.length; i++){
+        weight = module.exports.steradians(terms[i].lons, terms[i].lats)
+        sum += weight*terms[i].value
+    }
+
+    return sum
+}

--- a/spec.json
+++ b/spec.json
@@ -146,13 +146,13 @@
             }
          }
       },
-      "/covarIntegral": {
+      "/covarSum": {
          "get": {
             "tags": [
                "covar"
             ],
-            "summary": "Integral of probability distribution field over a region for a float starting at point lat-lon after forcastDays.",
-            "operationId": "integralCovar",
+            "summary": "Sum of probability distribution field over a region for a float starting at point lat-lon after forcastDays.",
+            "operationId": "sumCovar",
             "parameters": [
                {
                   "$ref": "#/components/parameters/lat"
@@ -175,10 +175,10 @@
                         "schema": {
                            "type": "object",
                            "required": [
-                              "integral"
+                              "sum"
                            ],
                            "properties": {
-                              "integral": {
+                              "sum": {
                                  "type": "integer"
                               }
                            }

--- a/tests/package.json
+++ b/tests/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "chai": "^4.3.4",
+    "chai-almost": "^1.0.1",
     "chai-json-schema": "^1.5.1",
     "mocha": "^9.1.1",
     "supertest": "^6.1.6"

--- a/tests/tests/covar.tests.js
+++ b/tests/tests/covar.tests.js
@@ -33,11 +33,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
-    describe("GET /covarIntegral", function () {
+    describe("GET /covarSum", function () {
       it("sums up part of a covar grid", async function () {
-        const response = await request.get("/covarIntegral?lon=98&lat=-58&forcastDays=140&polygon=[[-56.2,99],[-55.8,99],[-55.8,103],[-56.2,103],[-56.2,99]]").set({'x-argokey': 'developer'});    
+        const response = await request.get("/covarSum?lon=98&lat=-58&forcastDays=140&polygon=[[-56.2,99],[-55.8,99],[-55.8,103],[-56.2,103],[-56.2,99]]").set({'x-argokey': 'developer'});    
 
-        expect(response.body.integral).to.eql(0.14285714285714285+0.07142857142857142);
+        expect(response.body.sum).to.eql(0.14285714285714285+0.07142857142857142);
       });
     });
   }

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -1,0 +1,36 @@
+const request = require("supertest")("http://api:8080");
+const expect = require("chai").expect;
+const chai = require('chai');
+chai.use(require('chai-json-schema'));
+chai.use(require('chai-almost')(0.00000001));
+const rawspec = require('/tests/spec.json');
+const $RefParser = require("@apidevtools/json-schema-ref-parser");
+const helpers = require('/tests/tests/helpers')
+
+$RefParser.dereference(rawspec, (err, schema) => {
+  if (err) {
+    console.error(err);
+  }
+  else {
+
+    describe("steradians", function () {
+      it("sanity check steradian caclulation", async function () {
+        const sum = helpers.geoWeightedSum([{value: 1, lons: [0,180], lats: [0,90]}, {value: 2, lons: [0,90], lats: [0,90]}])
+        expect(helpers.steradians([0,360], [-90,90])).to.eql(4*Math.PI)  
+      });
+    }); 
+
+    describe("steradians", function () {
+      it("compares the area of two zones", async function () {
+        expect(helpers.steradians([0,360], [89,90])).to.be.lessThan(helpers.steradians([0,360], [0,1]))  
+      });
+    }); 
+
+    describe("geoWeightedSum", function () {
+      it("checks a simple weighted sum over geo regions", async function () {
+        const sum = helpers.geoWeightedSum([{value: 1, lons: [0,180], lats: [0,90]}, {value: 2, lons: [0,90], lats: [0,90]}])
+        expect(sum).to.almost.equal(2*Math.PI)  
+      });
+    }); 
+  }
+})


### PR DESCRIPTION
Anticipating some gridded products work in future, here's a helper to weight a sum by the steradians covered by associated grid cells. Useful for computing absolute values from surface densities, or doing area-weighted averages.

Also renames `integral` -> `sum` for cover integral endpoints, per Donata's suggestion.