### PR TITLE
Platform filter templates

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1327,21 +1327,9 @@ paths:
       tags:
       - platforms
       summary: Provides a list of platforms (all by default) with their most recent
-        known report and position. Can filter down to only those platforms with their
-        latest profile within a polygon.
+        known report and position.
       operationId: platformList
       parameters:
-      - name: polygon
-        in: query
-        description: "array of [lon, lat] vertices describing a polygon; final point\
-          \ must match initial point"
-        required: false
-        style: form
-        explode: true
-        allowReserved: true
-        schema:
-          type: string
-          example: "[[-74.1247,40.5972],[-73.7347,40.5972],[-74.0148,40.8886],[-74.1247,40.5972]]"
       - name: platforms
         in: query
         description: List of platform IDs

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1326,9 +1326,35 @@ paths:
     get:
       tags:
       - platforms
-      summary: Provides a list of all platforms with their most recent known report
-        and position.
+      summary: Provides a list of platforms (all by default) with their most recent
+        known report and position. Can filter down to only those platforms with their
+        latest profile within a polygon.
       operationId: platformList
+      parameters:
+      - name: polygon
+        in: query
+        description: "array of [lon, lat] vertices describing a polygon; final point\
+          \ must match initial point"
+        required: false
+        style: form
+        explode: true
+        allowReserved: true
+        schema:
+          type: string
+          example: "[[-74.1247,40.5972],[-73.7347,40.5972],[-74.0148,40.8886],[-74.1247,40.5972]]"
+      - name: platforms
+        in: query
+        description: List of platform IDs
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          items:
+            anyOf:
+            - type: string
+            - type: number
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/Platforms.js
+++ b/nodejs-server/controllers/Platforms.js
@@ -13,8 +13,8 @@ module.exports.bgcPlatformList = function bgcPlatformList (req, res, next) {
     });
 };
 
-module.exports.platformList = function platformList (req, res, next) {
-  Platforms.platformList()
+module.exports.platformList = function platformList (req, res, next, polygon, platforms) {
+  Platforms.platformList(polygon, platforms)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Platforms.js
+++ b/nodejs-server/controllers/Platforms.js
@@ -13,8 +13,8 @@ module.exports.bgcPlatformList = function bgcPlatformList (req, res, next) {
     });
 };
 
-module.exports.platformList = function platformList (req, res, next, polygon, platforms) {
-  Platforms.platformList(polygon, platforms)
+module.exports.platformList = function platformList (req, res, next, platforms) {
+  Platforms.platformList(platforms)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/PlatformsService.js
+++ b/nodejs-server/service/PlatformsService.js
@@ -20,13 +20,12 @@ exports.bgcPlatformList = function() {
 
 
 /**
- * Provides a list of platforms (all by default) with their most recent known report and position. Can filter down to only those platforms with their latest profile within a polygon.
+ * Provides a list of platforms (all by default) with their most recent known report and position.
  *
- * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
  * platforms List List of platform IDs (optional)
  * returns List
  **/
-exports.platformList = function(polygon,platforms) {
+exports.platformList = function(platforms) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/PlatformsService.js
+++ b/nodejs-server/service/PlatformsService.js
@@ -20,11 +20,13 @@ exports.bgcPlatformList = function() {
 
 
 /**
- * Provides a list of all platforms with their most recent known report and position.
+ * Provides a list of platforms (all by default) with their most recent known report and position. Can filter down to only those platforms with their latest profile within a polygon.
  *
+ * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
+ * platforms List List of platform IDs (optional)
  * returns List
  **/
-exports.platformList = function() {
+exports.platformList = function(polygon,platforms) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/spec.json
+++ b/spec.json
@@ -818,8 +818,16 @@
             "tags": [
                "platforms"
             ],
-            "summary": "Provides a list of all platforms with their most recent known report and position.",
+            "summary": "Provides a list of platforms (all by default) with their most recent known report and position. Can filter down to only those platforms with their latest profile within a polygon.",
             "operationId": "platformList",
+            "parameters": [
+               {
+                  "$ref": "#/components/parameters/polygon"
+               },
+               {
+                  "$ref": "#/components/parameters/platformList"
+               }
+            ],
             "responses": {
                "200": {
                   "description": "OK",

--- a/spec.json
+++ b/spec.json
@@ -818,12 +818,9 @@
             "tags": [
                "platforms"
             ],
-            "summary": "Provides a list of platforms (all by default) with their most recent known report and position. Can filter down to only those platforms with their latest profile within a polygon.",
+            "summary": "Provides a list of platforms (all by default) with their most recent known report and position.",
             "operationId": "platformList",
             "parameters": [
-               {
-                  "$ref": "#/components/parameters/polygon"
-               },
                {
                   "$ref": "#/components/parameters/platformList"
                }


### PR DESCRIPTION
Allow the `/platforms/mostRecent` endpoint to filter for less than all platforms