### PR TITLE
simplify data filtering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - docker network create travis
-  - docker container run -d --network travis --name database argovis/testdb:0.4
+  - docker container run -d --network travis --name database argovis/testdb:0.5
   - docker container run -d --network travis --name redis argovis/redis:6.2.6
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1037,17 +1037,6 @@ paths:
         schema:
           type: string
           example: argo_bgc
-      - name: datavars
-        in: query
-        description: AND list of variables to require in a profile
-        required: false
-        style: form
-        explode: false
-        allowReserved: true
-        schema:
-          type: array
-          items:
-            type: string
       - name: compression
         in: query
         description: Data compression strategy
@@ -1199,17 +1188,6 @@ paths:
         schema:
           type: string
           example: argo_bgc
-      - name: datavars
-        in: query
-        description: AND list of variables to require in a profile
-        required: false
-        style: form
-        explode: false
-        allowReserved: true
-        schema:
-          type: array
-          items:
-            type: string
       - name: platform
         in: query
         description: Platform ID
@@ -2030,6 +2008,7 @@ components:
       - up_radiance490_argoqc
       - up_radiance555_argoqc
       - all
+      - metadata-only
     goshipDataKey:
       type: string
       enum:
@@ -2687,18 +2666,6 @@ components:
       schema:
         type: string
         example: argo_bgc
-    datavars:
-      name: datavars
-      in: query
-      description: AND list of variables to require in a profile
-      required: false
-      style: form
-      explode: false
-      allowReserved: true
-      schema:
-        type: array
-        items:
-          type: string
     compression:
       name: compression
       in: query

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
 
-module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, datavars, compression, data) {
-  Profiles.profile(startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, datavars, compression, data)
+module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, compression, data) {
+  Profiles.profile(startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, compression, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })
@@ -13,8 +13,8 @@ module.exports.profile = function profile (req, res, next, startDate, endDate, p
     });
 };
 
-module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, center, radius, dac, source, woceline, datavars, platform, presRange, data) {
-  Profiles.profileList(startDate, endDate, polygon, box, center, radius, dac, source, woceline, datavars, platform, presRange, data)
+module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, center, radius, dac, source, woceline, platform, presRange, data) {
+  Profiles.profileList(startDate, endDate, polygon, box, center, radius, dac, source, woceline, platform, presRange, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -16,12 +16,11 @@
  * dac String Data Assembly Center (optional)
  * source String  (optional)
  * woceline String  (optional)
- * datavars List AND list of variables to require in a profile (optional)
  * compression String Data compression strategy (optional)
  * data List Keys of data to include (optional)
  * returns List
  **/
-exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platform,presRange,dac,source,woceline,datavars,compression,data) {
+exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platform,presRange,dac,source,woceline,compression,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {
@@ -128,13 +127,12 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platfo
  * dac String Data Assembly Center (optional)
  * source String  (optional)
  * woceline String  (optional)
- * datavars List AND list of variables to require in a profile (optional)
  * platform String Platform ID (optional)
  * presRange List Pressure range (optional)
  * data List Keys of data to include (optional)
  * returns List
  **/
-exports.profileList = function(startDate,endDate,polygon,box,center,radius,dac,source,woceline,datavars,platform,presRange,data) {
+exports.profileList = function(startDate,endDate,polygon,box,center,radius,dac,source,woceline,platform,presRange,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -40,7 +40,7 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platfo
     }
 
     // project out data here if we definitely don't need it
-    if(!data && !datavars && !presRange){
+    if(!data && !presRange){
       aggPipeline.push({$project: {data: 0}})
     }
 
@@ -57,10 +57,10 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platfo
         return; 
       }
 
-      profiles = helpers.filter_data(profiles, data, datavars, presRange)
+      profiles = helpers.filter_data(profiles, data, presRange)
 
       // reinflate data by default
-      if(data && !compression){
+      if(data && !compression && !data.includes('metadata-only')){
         profiles = profiles.map(p => reinflate(p))
       }
 
@@ -108,7 +108,7 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,dac,s
     }
 
     // project out data here if we definitely don't need it
-    if(!data && !datavars && !presRange){
+    if(!data && !presRange){
       aggPipeline.push({$project: {data: 0}})
     }
 
@@ -125,7 +125,7 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,dac,s
         return; 
       }
 
-      profiles = helpers.filter_data(profiles, data, datavars, presRange)
+      profiles = helpers.filter_data(profiles, data, presRange)
 
       if(profiles.length == 0) {
         reject({"code": 404, "message": "Not found: No matching results found in database."});

--- a/spec.json
+++ b/spec.json
@@ -651,9 +651,6 @@
                   "$ref": "#/components/parameters/woceline" 
                },
                {
-                  "$ref": "#/components/parameters/datavars" 
-               },
-               {
                   "$ref": "#/components/parameters/compression"
                },
                {
@@ -720,9 +717,6 @@
                },
                {
                   "$ref": "#/components/parameters/woceline" 
-               },
-               {
-                  "$ref": "#/components/parameters/datavars" 
                },
                {
                   "$ref": "#/components/parameters/profilePlatform"
@@ -1552,7 +1546,8 @@
                "up_radiance443_argoqc",
                "up_radiance490_argoqc",
                "up_radiance555_argoqc",
-               "all"]
+               "all",
+               "metadata-only"]
          },
          "goshipDataKey": {
             "type": "string",
@@ -2106,20 +2101,6 @@
                "type": "string",
                "example": "argo_bgc"
             } 
-         },
-         "datavars": {
-            "in": "query",
-            "name": "datavars",
-            "description": "AND list of variables to require in a profile",
-            "style": "form",
-            "explode": false,
-            "allowReserved": true,
-            "schema": {
-               "type": "array",
-               "items": {
-                  "type": "string"
-               }
-            }
          },
          "compression": {
             "in": "query",

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -52,7 +52,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
       it("rejects a profile for not having one of the requested variables", async function () {
         keys = ['temp', 'nitrate']
         profile = {'data_keys': ['temp', 'pres'], 'data': [[20,0], [19,10], [10,20]]}
-        expect(helpers.has_data(profile,keys)).to.be.false  
+        expect(helpers.has_data(profile,keys,false)).to.be.false  
       });
     }); 
 
@@ -60,7 +60,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
       it("rejects a profile for having nothing but nan in the requested variable", async function () {
         keys = ['temp', 'nitrate']
         profile = {'data_keys': ['nitrate', 'temp'], 'data': [[Number.NaN,0], [Number.NaN,10], [Number.NaN,20]]}
-        expect(helpers.has_data(profile,keys)).to.be.false  
+        expect(helpers.has_data(profile,keys,true)).to.be.false  
       });
     }); 
 
@@ -68,23 +68,23 @@ $RefParser.dereference(rawspec, (err, schema) => {
       it("rejects a profile with some but not all the desired data", async function () {
         keys = ['temp', 'nitrate']
         profile = {'data_keys': ['nitrate', 'pres'], 'data': [[1,0], [2,10], [3,20]]}
-        expect(helpers.has_data(profile,keys)).to.be.false 
+        expect(helpers.has_data(profile,keys,false)).to.be.false 
       });
     }); 
 
     describe("has_data", function () {
       it("accepts a profile with all the desired data", async function () {
-        keys = ['temp', 'nitrate']
-        profile = {'data_keys': ['nitrate', 'temp'], 'data': [[1,0], [2,10], [3,20]]}
-        expect(helpers.has_data(profile,keys)).to.be.true 
+        keys = ['pres', 'nitrate']
+        profile = {'data_keys': ['nitrate', 'pres'], 'data': [[1,0], [2,10], [3,20]]}
+        expect(helpers.has_data(profile,keys,false)).to.be.true 
       });
     }); 
 
     describe("has_data", function () {
       it("handles an empty data array", async function () {
-        keys = ['temp', 'nitrate']
-        profile = {'data_keys': ['nitrate', 'temp'], 'data': []}
-        expect(helpers.has_data(profile,keys)).to.be.false 
+        keys = ['pres', 'nitrate']
+        profile = {'data_keys': ['nitrate', 'pres'], 'data': []}
+        expect(helpers.has_data(profile,keys,true)).to.be.false 
       });
     }); 
   }

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -141,63 +141,35 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("should only return profiles with doxy", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return profiles with temp", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=temp").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(4)
       });
     });
 
     describe("GET /profiles", function () {
-      it("should only return profiles with temp and doxy (pt 1 - nominal case)", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=temp,doxy").set({'x-argokey': 'developer'});
-        expect(response.body.length).to.eql(3)
-      });
-    });
-
-    describe("GET /profiles", function () {
-      it("should only return profiles with temp and doxy (pt 2 - coerce datavars to a superset of data)", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=temp&data=doxy").set({'x-argokey': 'developer'});
-        expect(response.body.length).to.eql(3)
-      });
-    });
-
-    describe("GET /profiles", function () {
-      it("should only return profiles with temp and doxy (pt 3 - AND on data if datavars absent)", async function () {
+      it("should only return profiles with temp AND doxy", async function () {
         const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp,doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3)
       });
     });
 
     describe("GET /profiles", function () {
-      it("should handle data=all correctly in isolation", async function () {
+      it("should handle data=all correctly", async function () {
         const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=all").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(4)
       });
     });
 
     describe("GET /profiles", function () {
-      it("should handle data=all correctly in concert with datavars (pt 1)", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=doxy&data=all").set({'x-argokey': 'developer'});
-        expect(response.body.length).to.eql(3)
-      });
-    });
-
-    describe("GET /profiles", function () {
-      it("should handle data=all correctly in concert with datavars (pt 2)", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=doxy&data=all").set({'x-argokey': 'developer'});
-        expect(response.body[0].data_keys).to.have.members([ "doxy", "doxy_argoqc", "pres", "pres_argoqc", "psal", "psal_argoqc", "psal_sfile", "psal_sfile_argoqc", "temp", "temp_argoqc", "temp_sfile", "temp_sfile_argoqc" ])
-      });
-    });
-
-    describe("GET /profiles", function () {
       it("should not return anything due to presRange being empty", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&datavars=temp&presRange=10000,20000").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp&presRange=10000,20000").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });
@@ -208,5 +180,27 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body[0].data_keys).to.have.members(['doxy', 'pres'])
       });
     });
+
+    describe("GET /profiles", function () {
+      it("should not return a profile if it had coerced pressure alone", async function () {
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=chla").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+      });
+    });
+
+    describe("GET /profiles", function () {
+      it("should handle data='metadata-only", async function () {
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&id=2900448_060&data=metadata-only").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(1);
+      });
+    });
+
+    describe("GET /profiles", function () {
+      it("should suppress levels that don't have a doxy value", async function () {
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&id=2900448_060&data=doxy").set({'x-argokey': 'developer'});
+        expect(response.body[0].data[1].doxy).to.eql(258.24920654296875);
+      });
+    });
+
   }
 })


### PR DESCRIPTION
In order to make filtering by data less confusing, this PR makes the following moves:

 - the short-lived `datavars` has been removed. The difference between `data` and `datavars` was too arcane and would likely have led to confusion with users only to support a remote edge case. If people demand the remote edge case, we can bring it back.
 - data and metadata are now filtered by the `data` key per the following examples:
   - `data=doxy,pres` will only return profiles that include *both* dissolved oxygen and pressure, include only those two variables in the returned documents data arrays, and suppress any level that has *neither*.
   - `data=doxy` will filter for profiles that include *both* dissolved oxygen and pressure, include only those two variables in the returned documents data arrays, and suppress any level that *doesn't have dissolved oxygen*.
   - `data=doxy,pres,metadata-only` will filter for profiles that include *both* dissolved oxygen and pressure data, but will only return the metadata for those profiles.
   - `data=all` suppresses any filtering of profiles by present data, and returns everything available for profiles that match the rest of the query string.
   - Adding `presRange` to any of the above produces similar results, but only considering levels within the specified range.
