### PR TITLE
Aggregation optimization

### DIFF
--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -239,7 +239,7 @@ const profile_candidate_agg_pipeline = function(startDate,endDate,polygon,box,ce
 
     if(center && radius) {
       // $geoNear must be first in the aggregation pipeline
-      aggPipeline.push({$geoNear: { near: {type: "Point", coordinates: [center[0], center[1]]}, maxDistance: 1000*radius, distanceField: "distcalculated"}}) 
+      aggPipeline.push({$geoNear: {key: 'geolocation', near: {type: "Point", coordinates: [center[0], center[1]]}, maxDistance: 1000*radius, distanceField: "distcalculated"}}) 
       aggPipeline.push({ $unset: "distcalculated" })
     }
 


### PR DESCRIPTION
From the mongo docs, aggregation pipelines perform best with match queries up front, and will use an index on that match pipeline stage iff it's the _first_ pipeline stage. We can't leverage this for proximity searches any more than we already have, but this PR collapses `timestamp` and `geolocation` into the first aggregation step in all other cases; paired with a timestamp-geolocation compound index, this ought to be a better fit for many of our searches.