### PR TITLE
enforce size limits on area searches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM argovis/api:base-220424
+FROM argovis/api:base-220509
 COPY nodejs-server /app
 RUN cp mods/express.app.config.js /app/node_modules/oas3-tools/dist/middleware/express.app.config.js
 CMD npm start

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -748,6 +748,17 @@ paths:
         schema:
           type: number
           example: 0
+      - name: multipolygon
+        in: query
+        description: array of polygon regions; will return points interior to all
+          listed polygons
+        required: false
+        style: form
+        explode: true
+        allowReserved: true
+        schema:
+          type: string
+          example: "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
       - name: dac
         in: query
         description: Data Assembly Center

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -553,6 +553,17 @@ paths:
         schema:
           type: number
           example: 0
+      - name: multipolygon
+        in: query
+        description: array of polygon regions; will return points interior to all
+          listed polygons
+        required: false
+        style: form
+        explode: true
+        allowReserved: true
+        schema:
+          type: string
+          example: "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
       - name: id
         in: query
         description: Profile ID
@@ -2014,6 +2025,18 @@ components:
       schema:
         type: string
         example: "[[-74.1247,40.5972],[-73.7347,40.5972],[-74.0148,40.8886],[-74.1247,40.5972]]"
+    multipolygon:
+      name: multipolygon
+      in: query
+      description: array of polygon regions; will return points interior to all listed
+        polygons
+      required: false
+      style: form
+      explode: true
+      allowReserved: true
+      schema:
+        type: string
+        example: "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
     box:
       name: box
       in: query

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -426,6 +426,17 @@ paths:
         schema:
           type: string
           example: "[[-74.1247,40.5972],[-73.7347,40.5972],[-74.0148,40.8886],[-74.1247,40.5972]]"
+      - name: multipolygon
+        in: query
+        description: array of polygon regions; will return points interior to all
+          listed polygons
+        required: false
+        style: form
+        explode: true
+        allowReserved: true
+        schema:
+          type: string
+          example: "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
       - name: startDate
         in: query
         description: date-time formatted string indicating the beginning of a time

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Grid = require('../service/GridService');
 
-module.exports.gridselect = function gridselect (req, res, next, gridName, presRange, polygon, startDate, endDate) {
-  Grid.gridselect(gridName, presRange, polygon, startDate, endDate)
+module.exports.gridselect = function gridselect (req, res, next, gridName, presRange, polygon, multipolygon, startDate, endDate) {
+  Grid.gridselect(gridName, presRange, polygon, multipolygon, startDate, endDate)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
 
-module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, compression, data) {
-  Profiles.profile(startDate, endDate, polygon, box, center, radius, id, platform, presRange, dac, source, woceline, compression, data)
+module.exports.profile = function profile (req, res, next, startDate, endDate, polygon, box, center, radius, multipolygon, id, platform, presRange, dac, source, woceline, compression, data) {
+  Profiles.profile(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform, presRange, dac, source, woceline, compression, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -13,8 +13,8 @@ module.exports.profile = function profile (req, res, next, startDate, endDate, p
     });
 };
 
-module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, center, radius, dac, source, woceline, platform, presRange, data) {
-  Profiles.profileList(startDate, endDate, polygon, box, center, radius, dac, source, woceline, platform, presRange, data)
+module.exports.profileList = function profileList (req, res, next, startDate, endDate, polygon, box, center, radius, multipolygon, dac, source, woceline, platform, presRange, data) {
+  Profiles.profileList(startDate, endDate, polygon, box, center, radius, multipolygon, dac, source, woceline, platform, presRange, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "@turf/boolean-point-in-polygon": "^6.5.0",
+    "@mapbox/geojson-area": "^0.2.2",
     "connect": "^3.2.0",
     "cors": "^2.8.5",
     "debug": "3.1.0",

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -7,11 +7,12 @@
  * gridName String name of the gridded product
  * presRange List Pressure range (optional)
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point (optional)
+ * multipolygon String array of polygon regions; will return points interior to all listed polygons (optional)
  * startDate Date date-time formatted string indicating the beginning of a time period (optional)
  * endDate Date date-time formatted string indicating the end of a time period (optional)
  * returns List
  **/
-exports.gridselect = function(gridName,presRange,polygon,startDate,endDate) {
+exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,endDate) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -3,9 +3,8 @@ const Grid = require('../models/grid');
 const helpers = require('./helpers')
 const GJV = require('geojson-validation');
 const geojsonArea = require('@mapbox/geojson-area');
-
 const datePresGrouping = {_id: '$gridName', presLevels: {$addToSet: '$pres'}, dates: {$addToSet: '$date'}}
-
+const maxgeosearch = 2000000000000 //maximum geo region allowed in square meters
 /**
  * gridded product selector
  *
@@ -20,7 +19,7 @@ const datePresGrouping = {_id: '$gridName', presLevels: {$addToSet: '$pres'}, da
 exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,endDate) {
   return new Promise(function(resolve, reject) {
 
-    if(gridName && (typeof polygon == 'undefined' && typeof startDate == 'undefined' && typeof endDate == 'undefined' && typeof presRange == 'undefined')){
+    if(gridName && (typeof polygon == 'undefined' && typeof startDate == 'undefined' && typeof endDate == 'undefined' && typeof presRange == 'undefined' && typeof multipolygon == 'undefined')){
         // metadata only request
         const query = Grid['grids-meta'].aggregate([{$match:{"_id": gridName}}]);
 
@@ -41,10 +40,11 @@ exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,
         // regular data request
         // sanitation
 
-        if(typeof polygon == 'undefined' || typeof startDate == 'undefined' || typeof endDate == 'undefined'){
-            reject({"code": 400, "message": "Query string parameters gridName, polygon, startDate, and endDate are all required unless you are making a metadata-only request, in which case only gridName should be provided." }); 
+        if((typeof polygon == 'undefined' && typeof multipolygon == 'undefined') || typeof startDate == 'undefined' || typeof endDate == 'undefined'){
+            reject({"code": 400, "message": "Query string parameters gridName, startDate, endDate, and one of polygon or multipolygon are all required unless you are making a metadata-only request, in which case only gridName should be provided." }); 
         }
 
+        let spacetimeMatch = []
         startDate = new Date(startDate);
         endDate = new Date(endDate);
 
@@ -52,27 +52,45 @@ exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,
           reject({"code": 400, "message": gridName + " is not a supported grid; instead try one of: " + Object.getOwnPropertyNames(Grid)});  
         }
 
-        try {
-          polygon = JSON.parse(polygon);
-        } catch (e) {
-          reject({"code": 400, "message": "Polygon region wasn't proper JSON; format should be [[lon,lat],[lon,lat],...]"});
+        if(polygon) {
+          polygon = helpers.polygon_sanitation(polygon)
+          if(geojsonArea.geometry(polygon) > maxgeosearch){
+            return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
+          }
+
+          if(polygon.hasOwnProperty('code')){
+            // error, return and bail out
+            return polygon
+          }
+
+          spacetimeMatch = [{$match: {"g": {$geoWithin: {$geometry: polygon}}, "t": {$gte: startDate, $lte: endDate} }}]
         }
-        if(!helpers.validlonlat(polygon)){
-          reject({"code": 400, "message": "All lon, lat pairs must respect -180<=lon<=180 and -90<=lat<-90"}); 
-        }
-        polygon = {
-          "type": "Polygon",
-          "coordinates": [polygon]
-        }
-        if(!GJV.valid(polygon)){
-          reject({"code": 400, "message": "Polygon region wasn't proper geoJSON; format should be [[lon,lat],[lon,lat],...]"});
-        }
-        if(geojsonArea.geometry(polygon) > 1500000000000){
-          return {"code": 400, "message": "Polygon region is too big; please ask for 1.5 M square km or less in a single request, or about 10 square degrees at the equator."}
+
+        if(multipolygon){
+          try {
+            multipolygon = JSON.parse(multipolygon);
+          } catch (e) {
+            return {"code": 400, "message": "Multipolygon region wasn't proper JSON; format should be [[first polygon], [second polygon]], where each polygon is [lon,lat],[lon,lat],..."};
+          }
+          multipolygon = multipolygon.map(function(x){return helpers.polygon_sanitation(JSON.stringify(x))})
+          if(multipolygon.some(p => p.hasOwnProperty('code'))){
+            multipolygon = multipolygon.filter(x=>x.hasOwnProperty('code'))
+            return multipolygon
+          }
+          if(multipolygon.every(p => geojsonArea.geometry(p) > maxgeosearch)){
+            return {"code": 400, "message": "All Multipolygon regions are too big; at least one of them must be 2 M square km or less, or about 15 square degrees at the equator."}
+          }
+          multipolygon.sort((a,b)=>{geojsonArea.geometry(a) - geojsonArea.geometry(b)}) // smallest first to minimize size of unindexed geo search
+          //spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: multipolygon[0]}}
+
+          spacetimeMatch = [{$match: {"g": {$geoWithin: {$geometry: multipolygon[0]}}, "t": {$gte: startDate, $lte: endDate} }}]
+          for(let i=1; i<multipolygon.length; i++){
+            spacetimeMatch.push({$match: {"g": {$geoWithin: {$geometry: multipolygon[i]}}}})
+          }
         }
 
         Promise.all([
-            Grid[gridName].aggregate([{$match: {"g": {$geoWithin: {$geometry: polygon}}, "t": {$gte: startDate, $lte: endDate} }}]),
+            Grid[gridName].aggregate(spacetimeMatch),
             Grid['grids-meta'].aggregate([{$match:{"_id": gridName}}])
         ]).then( ([ grids, gridmeta]) => {
 

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -11,6 +11,7 @@ const datePresGrouping = {_id: '$gridName', presLevels: {$addToSet: '$pres'}, da
  *
  * gridName String name of the gridded product
  * polygon String array of [lon, lat] vertices describing a polygon; final point must match initial point
+ * multipolygon String array of polygon regions; will return points interior to all listed polygons (optional)
  * startDate Date date-time formatted string indicating the beginning of a time period
  * endDate Date date-time formatted string indicating the end of a time period
  * presRange List Pressure range (optional)
@@ -66,7 +67,7 @@ exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,
         if(!GJV.valid(polygon)){
           reject({"code": 400, "message": "Polygon region wasn't proper geoJSON; format should be [[lon,lat],[lon,lat],...]"});
         }
-        if(geojsonArea.geometry(polygon) > 2000000000000){
+        if(geojsonArea.geometry(polygon) > 1500000000000){
           return {"code": 400, "message": "Polygon region is too big; please ask for 1.5 M square km or less in a single request, or about 10 square degrees at the equator."}
         }
 

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -2,6 +2,7 @@
 const Grid = require('../models/grid');
 const helpers = require('./helpers')
 const GJV = require('geojson-validation');
+const geojsonArea = require('@mapbox/geojson-area');
 
 const datePresGrouping = {_id: '$gridName', presLevels: {$addToSet: '$pres'}, dates: {$addToSet: '$date'}}
 
@@ -65,6 +66,9 @@ exports.gridselect = function(gridName,polygon,startDate,endDate,presRange) {
         }
         if(!GJV.valid(polygon)){
           reject({"code": 400, "message": "Polygon region wasn't proper geoJSON; format should be [[lon,lat],[lon,lat],...]"});
+        }
+        if(geojsonArea.geometry(polygon) > 1500000000000){
+          return {"code": 400, "message": "Polygon region is too big; please ask for 1.5 M square km or less in a single request, or about 10 square degrees at the equator."}
         }
 
         Promise.all([

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -125,6 +125,7 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
  * box String box described as [[lower left lon, lower left lat], [upper right lon, upper right lat]] (optional)
  * center List center to measure max radius from (optional)
  * radius BigDecimal km from centerpoint (optional)
+ * multipolygon String array of polygon regions; will return points interior to all listed polygons (optional)
  * dac String Data Assembly Center (optional)
  * source List  (optional)
  * woceline String  (optional)
@@ -133,7 +134,7 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
  * data List Keys of data to include (optional)
  * returns List
  **/
-exports.profileList = function(startDate,endDate,polygon,box,center,radius,dac,source,woceline,platform,presRange,data) {
+exports.profileList = function(startDate,endDate,polygon,box,center,radius,multipolygon,dac,source,woceline,platform,presRange,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -10,6 +10,7 @@
  * box String box described as [[lower left lon, lower left lat], [upper right lon, upper right lat]] (optional)
  * center List center to measure max radius from (optional)
  * radius BigDecimal km from centerpoint (optional)
+ * multipolygon String array of polygon regions; will return points interior to all listed polygons (optional)
  * id String Profile ID (optional)
  * platform String Platform ID (optional)
  * presRange List Pressure range (optional)
@@ -20,7 +21,7 @@
  * data List Keys of data to include (optional)
  * returns List
  **/
-exports.profile = function(startDate,endDate,polygon,box,center,radius,id,platform,presRange,dac,source,woceline,compression,data) {
+exports.profile = function(startDate,endDate,polygon,box,center,radius,multipolygon,id,platform,presRange,dac,source,woceline,compression,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -203,3 +203,31 @@ module.exports.filter_data = function(profiles, data, presRange){
 
     return profiles
 }
+
+module.exports.polygon_sanitation = function(poly){
+  // given a string <poly> that describes a polygon as [[lon0,lat0],[lon1,lat1],...,[lonN,latN],[lon0,lat0]],
+  // make sure its formatted sensibly, and return it as a geojson polygon.
+  const GJV = require('geojson-validation')
+  let p = {}
+
+  try {
+    p = JSON.parse(poly);
+  } catch (e) {
+    return {"code": 400, "message": "Polygon region wasn't proper JSON; format should be [[lon,lat],[lon,lat],...]"};
+  }
+
+  if(!module.exports.validlonlat(p)){
+    return {"code": 400, "message": "All lon, lat pairs must respect -180<=lon<=180 and -90<=lat<-90"}; 
+  }
+
+  p = {
+    "type": "Polygon",
+    "coordinates": [p]
+  }
+
+  if(!GJV.valid(p)){
+    return {"code": 400, "message": "Polygon region wasn't proper geoJSON; format should be [[lon,lat],[lon,lat],...]"};
+  }
+
+  return p
+}

--- a/spec.json
+++ b/spec.json
@@ -369,6 +369,9 @@
                   "$ref": "#/components/parameters/radius"
                },
                {
+                  "$ref": "#/components/parameters/multipolygon"
+               },
+               {
                   "$ref": "#/components/parameters/profileID"
                },
                {
@@ -1544,6 +1547,16 @@
             "schema": {
                "type": "string",
                "example": "[[-74.1247,40.5972],[-73.7347,40.5972],[-74.0148,40.8886],[-74.1247,40.5972]]"
+            }
+         },
+         "multipolygon": {
+            "in": "query",
+            "name": "multipolygon",
+            "description": "array of polygon regions; will return points interior to all listed polygons",
+            "allowReserved": true,
+            "schema": {
+               "type": "string",
+               "example": "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
             }
          },
          "box": {

--- a/spec.json
+++ b/spec.json
@@ -310,6 +310,9 @@
                   "$ref": "#/components/parameters/polygon"
                },
                {
+                  "$ref": "#/components/parameters/multipolygon"
+               },
+               {
                   "$ref": "#/components/parameters/startDate"
                },
                {

--- a/spec.json
+++ b/spec.json
@@ -449,6 +449,9 @@
                   "$ref": "#/components/parameters/radius"
                },
                {
+                  "$ref": "#/components/parameters/multipolygon"
+               },
+               {
                   "$ref": "#/components/parameters/dac"
                },
                {

--- a/tests/tests/grid.tests.js
+++ b/tests/tests/grid.tests.js
@@ -33,6 +33,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /grids", function () {
+      it("fetch gridded data in overlap region between two polygons", async function () {
+        const response = await request.get("/grids?gridName=rgTempTotal&multipolygon=[[[20,-60],[30,-60],[30,-70],[20,-70],[20,-60]],[[20,-64],[22,-64],[22,-65],[20,-65],[20,-64]]]&startDate=2004-01-01T00:00:00Z&endDate=2004-02-01T00:00:00Z").set({'x-argokey': 'developer'});
+        response.body.shift() // first element is metadata, drop before cheking rest of schema
+        expect(response.body.length).to.eql(2);
+      });
+    });
+
   }
 })
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -237,5 +237,19 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /profiles", function () {
+      it("capture only the intersection with multipolygon", async function () {
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&multipolygon=[[[134,36],[135,36],[135,37],[134,37],[134,36]],[[134,36],[134.5,36],[134.5,37],[134,37],[134,36]]]").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(2);
+      });
+    });
+
+    describe("GET /profiles", function () {
+      it("multipolygon reject if all regions are too big", async function () {
+        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&multipolygon=[[[124,26],[145,26],[145,47],[124,47],[124,26]],[[124,26],[144.5,26],[144.5,47],[124,47],[124,26]]]").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(400);
+      });
+    });
+
   }
 })


### PR DESCRIPTION
Hackathon participants had a habit of asking for massive swaths of the globe in one request; this is not only slow, but eventually breaks mongodb's `geowithin`.

Might wait to merge this until a helper function for splitting large-area polygons is available.