### PR TITLE
request sanitation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - docker network create travis
-  - docker container run -d --network travis --name database argovis/testdb:0.9
+  - docker container run -d --network travis --name database argovis/testdb:0.10
   - docker container run -d --network travis --name redis argovis/redis:6.2.6
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .

--- a/nodejs-server/middleware/ratelimiter/tokenbucket.js
+++ b/nodejs-server/middleware/ratelimiter/tokenbucket.js
@@ -53,7 +53,7 @@ module.exports.tokenbucket = function (req, res, next) {
 		if(tokensnow-requestCost >= 0){
 			hsetAsync(userbucket.key, "ntokens", Math.max(tokensnow-requestCost,0), "lastUpdate", t).then(next())
 		} else {
-			throw({"code": 403, "message": "You have temporarily exceeded your API request limit. Try again in a minute, but limit your requests to small bursts, or wait a few seconds between requests long term."})
+			throw({"code": 429, "message": "You have temporarily exceeded your API request limit. Try again in a minute, but limit your requests to small bursts, or wait a few seconds between requests long term."})
 		}
 	})
 	.catch(err => {

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -4,7 +4,7 @@ const helpers = require('./helpers')
 const GJV = require('geojson-validation');
 const geojsonArea = require('@mapbox/geojson-area');
 const datePresGrouping = {_id: '$gridName', presLevels: {$addToSet: '$pres'}, dates: {$addToSet: '$date'}}
-const maxgeosearch = 2000000000000 //maximum geo region allowed in square meters
+const maxgeosearch = 3000000000000 //maximum geo region allowed in square meters
 /**
  * gridded product selector
  *
@@ -54,13 +54,14 @@ exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,
 
         if(polygon) {
           polygon = helpers.polygon_sanitation(polygon)
-          if(geojsonArea.geometry(polygon) > maxgeosearch){
-            return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
-          }
 
           if(polygon.hasOwnProperty('code')){
             // error, return and bail out
             return polygon
+          }
+
+          if(geojsonArea.geometry(polygon) > maxgeosearch){
+            return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
           }
 
           spacetimeMatch = [{$match: {"g": {$geoWithin: {$geometry: polygon}}, "t": {$gte: startDate, $lte: endDate} }}]

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -2,7 +2,7 @@
 const Profile = require('../models/profile');
 const helpers = require('./helpers')
 const geojsonArea = require('@mapbox/geojson-area');
-const maxgeosearch = 2000000000000 //maximum geo region allowed in square meters
+const maxgeosearch = 3000000000000 //maximum geo region allowed in square meters
 /**
  * Search, reduce and download profile data.
  *
@@ -260,13 +260,14 @@ const profile_candidate_agg_pipeline = function(startDate,endDate,polygon,box,ce
 
     if(polygon) {
       polygon = helpers.polygon_sanitation(polygon)
-      if(geojsonArea.geometry(polygon) > maxgeosearch){
-        return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
-      }
 
       if(polygon.hasOwnProperty('code')){
         // error, return and bail out
         return polygon
+      }
+
+      if(geojsonArea.geometry(polygon) > maxgeosearch){
+        return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
       }
 
       spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: polygon}}

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -26,10 +26,7 @@ const maxgeosearch = 3000000000000 //maximum geo region allowed in square meters
 exports.profile = function(startDate,endDate,polygon,box,center,radius,multipolygon,id,platform,presRange,dac,source,woceline,compression,data) {
   return new Promise(function(resolve, reject) {
 
-    if((!endDate || !startDate) && !id) {
-      reject({"code": 400, "message": "Please specify at least a date range with startDate AND endDate, OR a single profile id."});
-      return; 
-    }
+    // parse inputs
     if(startDate){
       startDate = new Date(startDate);
     }
@@ -37,9 +34,49 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
       endDate = new Date(endDate);
     }
 
+    if(polygon){
+      polygon = helpers.polygon_sanitation(polygon)
+
+      if(polygon.hasOwnProperty('code')){
+        // error, return and bail out
+        reject(polygon)
+        return
+      }
+    }
+    if(box){
+      box = helpers.box_sanitation(box)
+
+      if(box.hasOwnProperty('code')){
+        // error, return and bail out
+        reject(box)
+        return
+      }
+    }
+    if(multipolygon){
+      try {
+        multipolygon = JSON.parse(multipolygon);
+      } catch (e) {
+        reject({"code": 400, "message": "Multipolygon region wasn't proper JSON; format should be [[first polygon], [second polygon]], where each polygon is [lon,lat],[lon,lat],..."});
+        return
+      }
+      multipolygon = multipolygon.map(function(x){return helpers.polygon_sanitation(JSON.stringify(x))})
+      if(multipolygon.some(p => p.hasOwnProperty('code'))){
+        multipolygon = multipolygon.filter(x=>x.hasOwnProperty('code'))
+        reject(multipolygon[0])
+        return
+      } 
+    }
+
+    let bailout = helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)
+    if(bailout){
+      //request looks huge, reject it
+      reject(bailout)
+      return
+    }
+
     let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,center,radius,multipolygon,id,platform,dac,source,woceline)
 
-    if('code' in aggPipeline){
+    if(aggPipeline.hasOwnProperty('code')){
       reject(aggPipeline);
       return;
     }
@@ -55,11 +92,6 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
       if (err){
         reject({"code": 500, "message": "Server error"});
         return;
-      }
-
-      if(profiles.length > 1000){
-        reject({"code": 400, "message": "Your query is too broad and matched too many profiles; please use the filters to make a narrower request, and feel free to make multiple requests to cover more cases."});
-        return; 
       }
 
       profiles = helpers.filter_data(profiles, data, presRange)
@@ -99,10 +131,8 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
  **/
 exports.profileList = function(startDate,endDate,polygon,box,center,radius,multipolygon,dac,source,woceline,platform,presRange,data) {
   return new Promise(function(resolve, reject) {
-    if((!endDate || !startDate) && !id) {
-      reject({"code": 400, "message": "Please specify at least a date range with startDate AND endDate, OR a single profile id."});
-      return; 
-    }
+
+    // parse inputs
     if(startDate){
       startDate = new Date(startDate);
     }
@@ -110,9 +140,50 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,multi
       endDate = new Date(endDate);
     }
 
+    if(polygon){
+      polygon = helpers.polygon_sanitation(polygon)
+
+      if(polygon.hasOwnProperty('code')){
+        // error, return and bail out
+        reject(polygon)
+        return
+      }
+    }
+    if(box){
+      box = helpers.box_sanitation(box)
+
+      if(box.hasOwnProperty('code')){
+        // error, return and bail out
+        reject(box)
+        return
+      }
+    }
+    if(multipolygon){
+      try {
+        multipolygon = JSON.parse(multipolygon);
+      } catch (e) {
+        reject({"code": 400, "message": "Multipolygon region wasn't proper JSON; format should be [[first polygon], [second polygon]], where each polygon is [lon,lat],[lon,lat],..."});
+        return
+      }
+      multipolygon = multipolygon.map(function(x){return helpers.polygon_sanitation(JSON.stringify(x))})
+      if(multipolygon.some(p => p.hasOwnProperty('code'))){
+        multipolygon = multipolygon.filter(x=>x.hasOwnProperty('code'))
+        reject(multipolygon[0])
+        return
+      } 
+    }
+    console.log(1000, startDate, endDate, polygon, data)
+    let bailout = helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, null, platform)
+    console.log(2000, bailout)
+    if(bailout){
+      //request looks huge, reject it
+      reject(bailout)
+      return
+    }
+
     let aggPipeline = profile_candidate_agg_pipeline(startDate,endDate,polygon,box,center,radius,multipolygon,null,platform,dac,source,woceline)
 
-    if('code' in aggPipeline){
+    if(aggPipeline.hasOwnProperty('code')){
       reject(aggPipeline);
       return;
     }
@@ -129,12 +200,6 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,multi
         reject({"code": 500, "message": "Server error"});
         return;
       }
-
-      if(profiles.length > 10000){
-        reject({"code": 400, "message": "Your query is too broad and matched too many profiles; please use the filters to make a narrower request, and feel free to make multiple requests to cover more cases."});
-        return; 
-      }
-
       profiles = helpers.filter_data(profiles, data, presRange)
 
       if(profiles.length == 0) {
@@ -259,65 +324,29 @@ const profile_candidate_agg_pipeline = function(startDate,endDate,polygon,box,ce
     }
 
     if(polygon) {
-      polygon = helpers.polygon_sanitation(polygon)
-
-      if(polygon.hasOwnProperty('code')){
-        // error, return and bail out
-        return polygon
-      }
-
       if(geojsonArea.geometry(polygon) > maxgeosearch){
-        return {"code": 400, "message": "Polygon region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
+        return {"code": 400, "message": "Polygon region is too big; please ask for 3 M square km or less in a single request, or about 15 deg x 15 deg at the equator."}
       }
 
       spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: polygon}}
     }
 
     if(box) {
-      // sanitation
-      try {
-        box = JSON.parse(box);
-      } catch (e) {
-        return {"code": 400, "message": "Box region wasn't proper JSON; format should be [[lower left lon,lower left lat],[upper right lon,upper right lat]]"};
-      }
-      if(box.length != 2 || 
-         box[0].length != 2 || 
-         box[1].length != 2 || 
-         typeof box[0][0] != 'number' ||
-         typeof box[0][1] != 'number' ||
-         typeof box[1][0] != 'number' || 
-         typeof box[1][1] != 'number') {
-        return {"code": 400, "message": "Box region wasn't specified correctly; format should be [[lower left lon,lower left lat],[upper right lon,upper right lat]]"};
-      }
-
-      if(!helpers.validlonlat(box)){
-        return {"code": 400, "message": "All lon, lat pairs must respect -180<=lon<=180 and -90<=lat<-90"}; 
-      }
-
       let polybox = {
         "type": "Polygon",
         "coordinates": [[[box[0][0], box[0][1]], [box[1][0], box[0][1]], [box[1][0], box[1][1]], [box[0][0], box[1][1]], [box[0][0], box[0][1]]]]
       }
       if(geojsonArea.geometry(polybox) > maxgeosearch){
-        return {"code": 400, "message": "Box region is too big; please ask for 2 M square km or less in a single request, or about 15 square degrees at the equator."}
+        return {"code": 400, "message": "Box region is too big; please ask for 3 M square km or less in a single request, or about 15 deg x 15 deg at the equator."}
       }
 
       spacetimeMatch['geolocation'] = {$geoWithin: {$box: box}}
     }
 
     if(multipolygon){
-      try {
-        multipolygon = JSON.parse(multipolygon);
-      } catch (e) {
-        return {"code": 400, "message": "Multipolygon region wasn't proper JSON; format should be [[first polygon], [second polygon]], where each polygon is [lon,lat],[lon,lat],..."};
-      }
-      multipolygon = multipolygon.map(function(x){return helpers.polygon_sanitation(JSON.stringify(x))})
-      if(multipolygon.some(p => p.hasOwnProperty('code'))){
-        multipolygon = multipolygon.filter(x=>x.hasOwnProperty('code'))
-        return multipolygon
-      }
+
       if(multipolygon.every(p => geojsonArea.geometry(p) > maxgeosearch)){
-        return {"code": 400, "message": "All Multipolygon regions are too big; at least one of them must be 2 M square km or less, or about 15 square degrees at the equator."}
+        return {"code": 400, "message": "All Multipolygon regions are too big; at least one of them must be 3 M square km or less, or about 15 deg x 15 deg at the equator."}
       }
       multipolygon.sort((a,b)=>{geojsonArea.geometry(a) - geojsonArea.geometry(b)}) // smallest first to minimize size of unindexed geo search
       spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: multipolygon[0]}}

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -172,9 +172,8 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,multi
         return
       } 
     }
-    console.log(1000, startDate, endDate, polygon, data)
+
     let bailout = helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, null, platform)
-    console.log(2000, bailout)
     if(bailout){
       //request looks huge, reject it
       reject(bailout)

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -258,36 +258,70 @@ module.exports.box_sanitation = function(box){
   return box
 }
 
-module.exports.request_scoping = function(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform){
+module.exports.request_sanitation = function(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform){
   // given some parameters from a requst, decide whether or not to reject; return false == don't reject, return with message / code if do reject
   const geojsonArea = require('@mapbox/geojson-area');
 
-  if(id || platform){
-    // always allow single ID or platform
-    return false
+  // basic sanity checks
+  if((center && box) || (center && polygon) || (box && polygon)){
+    return {"code": 400, "message": "Please request only one of box, polygon or center."} 
+  }
+  if((center && !radius) || (!center && radius)){
+    return {"code": 400, "message": "Please specify both radius and center to filter for profiles less than <radius> km from <center>."}
   }
 
+  // geo size limits - mongo doesn't like huge geoWithins
+  maxgeosearch = 45000000000000 // 60 degree box centered on equator, in sq m
+  if(radius) {
+    if(radius > 3000){
+      return {"code": 400, "message": "Please limit proximity searches to at most 3000 km in radius"};
+    }
+  }
+  if(polygon) {
+    if(geojsonArea.geometry(polygon) > maxgeosearch){
+      return {"code": 400, "message": "Polygon region is too big; please ask for 45 M square km or less in a single request, or about 60 deg x 60 deg at the equator."}
+    }
+  }
+  if(box) {
+    let polybox = {
+      "type": "Polygon",
+      "coordinates": [[[box[0][0], box[0][1]], [box[1][0], box[0][1]], [box[1][0], box[1][1]], [box[0][0], box[1][1]], [box[0][0], box[0][1]]]]
+    }
+    if(geojsonArea.geometry(polybox) > maxgeosearch){
+      return {"code": 400, "message": "Box region is too big; please ask for 45 M square km or less in a single request, or about 60 deg x 60 deg at the equator."}
+    }
+  }
+  if(multipolygon){
+    if(multipolygon.every(p => geojsonArea.geometry(p) > maxgeosearch)){
+      return {"code": 400, "message": "All Multipolygon regions are too big; at least one of them must be 45 M square km or less, or about 60 deg x 60 deg at the equator."}
+    }
+  }
+
+  // data volume limits
+  if(id || platform){
+    // always allow single ID or platform searches at this point
+    return false
+  }
   if(!startDate){
     startDate = new Date('1980-01-01T00:00:00Z')
   }
   if(!endDate){
     endDate = new Date()
   }
-
   let dayspan = Math.round(Math.abs((endDate - startDate) / (24*60*60*1000) )); // n days of request
-
-  let geospan = 360*180*0.7 // rough number of 1 deg grid points covered by request; if no geo in request, estimate as 70% of all 1 deg grid points, ie the entire ocean
+  let geospan = 41252.96125*0.7 // square degrees covered by earth's ocean, equivalent to the entire globe for our purposes
   if(polygon){
-    geospan = geojsonArea.geometry(polygon) / 3000000000000 * 225 // 15 deg x 15 deg is about 3M square km at the equator
+    console.log(polygon, geojsonArea.geometry(polygon))
+    geospan = geojsonArea.geometry(polygon) / 13000000000 // 1 sq degree is about 13B sq meters
   } else if(box){
     geospan = Math.abs(box[0][0] - box[1][0])*Math.abs(box[0][1] - box[1][1])
   } else if(center && radius){
-    geospan = 3.14159*radius*radius / 3000000 * 225
+    geospan = 3.14159*radius*radius / 13000 // recall radius is reported in km
   } else if(multipolygon){
-    let areas = multipolygon.map(x => geojsonArea.geometry(x) / 3000000000000 * 225)
+    let areas = multipolygon.map(x => geojsonArea.geometry(x) / 13000000000)
     geospan = Math.min(areas)
   }
-
+  console.log(dayspan, geospan, dayspan*geospan)
   if(dayspan*geospan > 50000){
     return {"code":413, "message": "The estimated size of your request is pretty big; please split it up into a few smaller requests. To get an idea of how to scope your requests, and depending on your needs, you may consider asking for a 1 degree by 1 degree region for all time; a 15 deg by 15 deg region for 6 months; or the entire globe for a day. Or, try asking for specific profile IDs or platform IDs, where applicable."};
   }

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -261,21 +261,21 @@ module.exports.box_sanitation = function(box){
 module.exports.request_scoping = function(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform){
   // given some parameters from a requst, decide whether or not to reject; return false == don't reject, return with message / code if do reject
   const geojsonArea = require('@mapbox/geojson-area');
-  console.log(1100)
+
   if(id || platform){
     // always allow single ID or platform
     return false
   }
-  console.log(1200)
+
   if(!startDate){
     startDate = new Date('1980-01-01T00:00:00Z')
   }
   if(!endDate){
     endDate = new Date()
   }
-  console.log(1300)
+
   let dayspan = Math.round(Math.abs((endDate - startDate) / (24*60*60*1000) )); // n days of request
-  console.log(1400, dayspan)
+
   let geospan = 360*180*0.7 // rough number of 1 deg grid points covered by request; if no geo in request, estimate as 70% of all 1 deg grid points, ie the entire ocean
   if(polygon){
     geospan = geojsonArea.geometry(polygon) / 3000000000000 * 225 // 15 deg x 15 deg is about 3M square km at the equator
@@ -288,9 +288,8 @@ module.exports.request_scoping = function(startDate, endDate, polygon, box, cent
     geospan = Math.min(areas)
   }
 
-  console.log(dayspan, geospan)
   if(dayspan*geospan > 50000){
-    return {"code":400, "message": "The estimated size of your request is pretty big; please split it up into a few smaller requests. To get an idea of how to scope your requests, and depending on your needs, you may consider asking for a 2 degree by 2 degree region for all time; a 15 deg by 15 deg region for 6 months; or the entire globe for a day. Or, try asking for specific profile IDs or platform IDs, where applicable."};
+    return {"code":413, "message": "The estimated size of your request is pretty big; please split it up into a few smaller requests. To get an idea of how to scope your requests, and depending on your needs, you may consider asking for a 1 degree by 1 degree region for all time; a 15 deg by 15 deg region for 6 months; or the entire globe for a day. Or, try asking for specific profile IDs or platform IDs, where applicable."};
   }
 
   return false

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
   "license": "Unlicense",
   "private": true,
   "dependencies": {
+    "@mapbox/geojson-area": "^0.2.2",
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "chai": "^4.3.4",
     "chai-almost": "^1.0.1",

--- a/tests/tests/grid.tests.js
+++ b/tests/tests/grid.tests.js
@@ -41,6 +41,12 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /grids", function () {
+      it("reject a huge request", async function () {
+        const response = await request.get("/grids?gridName=rgTempTotal&startDate=2020-01-01T00:00:00Z&endDate=2021-01-01T00:00:00Z&polygon=[[0,-30],[60,-30],[60,30],[0,30],[0,-30]]").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(413);
+      });
+    });
   }
 })
 

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -86,6 +86,111 @@ $RefParser.dereference(rawspec, (err, schema) => {
         profile = {'data_keys': ['nitrate', 'pres'], 'data': []}
         expect(helpers.has_data(profile,keys,true)).to.be.false 
       });
+    });
+
+    describe("request_scoping", function () {
+      it("allows the whole globe for a day", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-01-02T00:00:00Z')
+        polygon = null
+        box = null
+        center = null
+        radius = null
+        multipolygon = null
+        id = null
+        platform = null
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      });
+    });
+
+    describe("request_scoping", function () {
+      it("allows a 15 degree box near the equator for 6 months", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-07-01T00:00:00Z')
+        polygon = null
+        box = [[0,-7.5],[15,7.5]]
+        center = null
+        radius = null
+        multipolygon = null
+        id = null
+        platform = null
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      });
     }); 
+
+    describe("request_scoping", function () {
+      it("disallows a 20 degree box near the equator for 6 months", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-07-01T00:00:00Z')
+        polygon = null
+        box = [[0,-10],[20,10]]
+        center = null
+        radius = null
+        multipolygon = null
+        id = null
+        platform = null
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.have.property('code', 413) 
+      });
+    });
+
+    describe("request_scoping", function () {
+      it("allows a 15 degree box as a polygon near the equator for 6 months", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-07-01T00:00:00Z')
+        polygon = {"type": "Polygon","coordinates": [[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]]}
+        box = null
+        center = null
+        radius = null
+        multipolygon = null
+        id = null
+        platform = null
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      });
+    });
+
+    describe("request_scoping", function () {
+      it("allows a 20 degree box near the equator for 6 months if an ID is also present", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-07-01T00:00:00Z')
+        polygon = null
+        box = [[0,-10],[20,10]]
+        center = null
+        radius = null
+        multipolygon = null
+        id = 'test-id'
+        platform = null
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      });
+    }); 
+
+    describe("request_scoping", function () {
+      it("allows a 20 degree box near the equator for 6 months if an ID is also present", async function () {
+        startDate = new Date('2020-01-01T00:00:00Z')
+        endDate = new Date('2020-07-01T00:00:00Z')
+        polygon = null
+        box = [[0,-10],[20,10]]
+        center = null
+        radius = null
+        multipolygon = null
+        id = null
+        platform = 'test-platform'
+        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      });
+    });   
   }
+
+  describe("request_scoping", function () {
+    it("allows a 2 degree box near the equator for all time", async function () {
+      startDate = null
+      endDate = null
+      polygon = null
+      box = [[0,-0.5],[1,0.5]]
+      center = null
+      radius = null
+      multipolygon = null
+      id = null
+      platform = null
+      expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+    });
+  }); 
 })

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -88,7 +88,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("allows the whole globe for a day", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-01-02T00:00:00Z')
@@ -99,11 +99,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
       });
     });
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("allows a 15 degree box near the equator for 6 months", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
@@ -114,11 +114,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
       });
     }); 
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("disallows a 20 degree box near the equator for 6 months", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
@@ -129,11 +129,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.have.property('code', 413) 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.have.property('code', 413) 
       });
     });
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("allows a 15 degree box as a polygon near the equator for 6 months", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
@@ -144,11 +144,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
       });
     });
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("allows a 20 degree box near the equator for 6 months if an ID is also present", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
@@ -159,11 +159,11 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = 'test-id'
         platform = null
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
       });
     }); 
 
-    describe("request_scoping", function () {
+    describe("request_sanitation", function () {
       it("allows a 20 degree box near the equator for 6 months if an ID is also present", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
@@ -174,12 +174,12 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = 'test-platform'
-        expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
       });
     });   
   }
 
-  describe("request_scoping", function () {
+  describe("request_sanitation", function () {
     it("allows a 2 degree box near the equator for all time", async function () {
       startDate = null
       endDate = null
@@ -190,7 +190,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
       multipolygon = null
       id = null
       platform = null
-      expect(helpers.request_scoping(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
     });
   }); 
 })

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -246,8 +246,15 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("multipolygon reject if all regions are too big", async function () {
-        const response = await request.get("/profiles?multipolygon=[[[124,26],[145,26],[145,47],[124,47],[124,26]],[[124,26],[144.5,26],[144.5,47],[124,47],[124,26]]]").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?multipolygon=[[[0,-35],[70,-35],[70,35],[0,35],[0,-35]],[20,-35],[90,-35],[90,35],[20,35],[20,-35]]").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(400);
+      });
+    });
+
+    describe("GET /profiles", function () {
+      it("reject a huge request", async function () {
+        const response = await request.get("/profiles?startDate=2020-01-01T00:00:00Z&endDate=2021-01-01T00:00:00Z&polygon=[[0,-30],[60,-30],[60,30],[0,30],[0,-30]]").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(413);
       });
     });
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -12,7 +12,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
   else {
     describe("GET /profiles", function () {
       it("searches for profiles by date", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00.000Z&endDate=2006-04-16T00:00:00.000Z&compression=basic").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/profiles'].get.responses['200'].content['application/json'].schema);
       });
     });
@@ -41,7 +41,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("gets profiles for one platform", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&platform=2900448&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?platform=2900448&compression=basic").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/profiles'].get.responses['200'].content['application/json'].schema);
       });
     });
@@ -69,14 +69,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("should find 2 profiles within a 20 km of this point", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&platform=2900448&center=134.25,36.16&radius=20&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?platform=2900448&center=134.25,36.16&radius=20&compression=basic").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(2)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return KO profiles", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&dac=KO&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&dac=KO&compression=basic").set({'x-argokey': 'developer'});
         dacs = response.body.map(p => p.data_center)
         s = new Set(dacs)
         expect(Array.from(s)).to.eql(['KO'])
@@ -85,7 +85,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("fails to find any nitrate in BGC measurements", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&data=nitrate&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=nitrate&compression=basic").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });   
@@ -106,147 +106,147 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles/listID", function () {
       it("lists the IDs of any profile with doxy data", async function () {
-        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&data=doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=doxy").set({'x-argokey': 'developer'});
         expect(response.body).to.have.members(['2900448_060','2900448_061'])  
       });
     }); 
 
     describe("GET /profiles/listID", function () {
       it("lists the IDs of any profile with a core salinity measurement", async function () {
-        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&data=psal").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=psal").set({'x-argokey': 'developer'});
         expect(response.body).to.have.members(['2900448_060','2900448_061'])
       });
     }); 
 
     describe("GET /profiles/listID", function () {
       it("fails to find any profile IDs with nitrate in BGC measurements", async function () {
-        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&data=nitrate").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles/listID?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=nitrate").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });   
 
     describe("GET /profiles/listID", function () {
-      it("fails to find a profile with core salinity measurement on the given day", async function () {
-        const response = await request.get("/profiles/listID?startDate=2006-04-16T00:00:00Z&endDate=2006-04-17T00:00:00Z&data=psal").set({'x-argokey': 'developer'});
+      it("fails to find a profile with doxy on the given day", async function () {
+        const response = await request.get("/profiles/listID?startDate=2006-05-17T00:00:00.000Z&endDate=2006-05-18T00:00:00.000Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=doxy").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return bgc profiles", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&source=argo_bgc").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&source=argo_bgc").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return argo_core profiles that dont have associated argo_bgc", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&source=argo_core,~argo_bgc").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&source=argo_core,~argo_bgc").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return profiles with doxy", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return profiles with temp", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=temp").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(4)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return profiles with temp AND doxy", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp,doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=temp,doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3)
       });
     });
 
     describe("GET /profiles", function () {
       it("should handle data=all correctly", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=all").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=all").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(4)
       });
     });
 
     describe("GET /profiles", function () {
       it("should not return anything due to presRange being empty", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=temp&presRange=10000,20000").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=temp&presRange=10000,20000").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });
 
     describe("GET /profiles", function () {
       it("should append pres even if not requested", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=doxy").set({'x-argokey': 'developer'});
         expect(response.body[0].data_keys).to.have.members(['doxy', 'pres'])
       });
     });
 
     describe("GET /profiles", function () {
       it("should not return a profile if it had coerced pressure alone", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=chla").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=chla").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });
 
     describe("GET /profiles", function () {
       it("should handle data='metadata-only", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&id=2900448_060&data=metadata-only").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?id=2900448_060&data=metadata-only").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /profiles", function () {
       it("should suppress levels that don't have a doxy value", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&id=2900448_060&data=doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?id=2900448_060&data=doxy").set({'x-argokey': 'developer'});
         expect(response.body[0].data[1].doxy).to.eql(258.24920654296875);
       });
     });
 
     describe("GET /profiles", function () {
       it("should suppress anything with dissolved oxygen", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=pres,psal,~doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=pres,psal,~doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /profiles", function () {
       it("should suppress anything with dissolved oxygen, in isolation", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=~doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=~doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /profiles", function () {
       it("make sure metadata-only interacts nicely with data negation", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=metadata-only,~doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=metadata-only,~doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /profiles", function () {
       it("make sure data=all interacts nicely with data negation", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&data=all,~doxy").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-05-18T00:00:00Z&polygon=[[133.330078125,38.89103282648846],[133.0224609375,35.639441068973944],[135.4833984375,35.71083783530009],[135.615234375,38.75408327579141],[133.330078125,38.89103282648846]]&data=all,~doxy").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /profiles", function () {
       it("capture only the intersection with multipolygon", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&multipolygon=[[[134,36],[135,36],[135,37],[134,37],[134,36]],[[134,36],[134.5,36],[134.5,37],[134,37],[134,36]]]").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?multipolygon=[[[134,36],[135,36],[135,37],[134,37],[134,36]],[[134,36],[134.5,36],[134.5,37],[134,37],[134,36]]]").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(2);
       });
     });
 
     describe("GET /profiles", function () {
       it("multipolygon reject if all regions are too big", async function () {
-        const response = await request.get("/profiles?startDate=1900-01-01T00:00:00Z&endDate=2100-01-01T00:00:00Z&multipolygon=[[[124,26],[145,26],[145,47],[124,47],[124,26]],[[124,26],[144.5,26],[144.5,47],[124,47],[124,26]]]").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?multipolygon=[[[124,26],[145,26],[145,47],[124,47],[124,26]],[[124,26],[144.5,26],[144.5,47],[124,47],[124,26]]]").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(400);
       });
     });


### PR DESCRIPTION
 - make accept-or-reject decisions based purely on the query string, not a db query. 
      - much faster for the user and less resource intensive for us
      - consider the product of geographic and time extent, and limit on this to maximize flexibility
      - dramatically enlarge maximum geo size, within Mongo's geowithin limits, relying on previous point to limit data size
      - Thresholds tuned to allow about 1000 profiles in a request, but no longer strictly enforced.
 - move all request sanitation logic to a single function, run up front before the db is searched