### PR TITLE
precomputed summary routes, chrono sort

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1114,6 +1114,76 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Platforms
+  /platforms/bgc:
+    get:
+      tags:
+      - platforms
+      summary: Provides a list of all Argo platform IDs with BGC data.
+      operationId: platformBGC
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                x-content-type: application/json
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Platforms
+  /dacs:
+    get:
+      tags:
+      - dacs
+      summary: Provides summary data for each data assembly center.
+      operationId: dacSummary
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/parameters/dacSummary'
+                x-content-type: application/json
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Dacs
 components:
   schemas:
     arShapeSchema:
@@ -1797,7 +1867,7 @@ components:
           - 0.80082819046101150206595775671303272247314453125
           - 0.80082819046101150206595775671303272247314453125
           type: type
-    dacStub:
+    dacSummary:
       type: object
       properties:
         _id:
@@ -1809,6 +1879,11 @@ components:
           format: date-time
         dac:
           type: string
+      example:
+        most_recent_date: 2000-01-23T04:56:07.000+00:00
+        dac: dac
+        number_of_profiles: 0
+        _id: _id
     profileCollectionSummary:
       type: object
       properties:

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1126,10 +1126,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
-                x-content-type: application/json
+                $ref: '#/components/schemas/summary'
         "400":
           description: Bad Request
           content:
@@ -1161,10 +1158,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/dacSummary'
-                x-content-type: application/json
+                $ref: '#/components/schemas/summary'
         "400":
           description: Bad Request
           content:
@@ -1867,22 +1861,15 @@ components:
           - 0.80082819046101150206595775671303272247314453125
           - 0.80082819046101150206595775671303272247314453125
           type: type
-    dacSummary:
+    summary:
       type: object
       properties:
         _id:
           type: string
-        number_of_profiles:
-          type: integer
-        most_recent_date:
-          type: string
-          format: date-time
-        dac:
-          type: string
+        summary:
+          type: object
       example:
-        most_recent_date: 2000-01-23T04:56:07.000+00:00
-        dac: dac
-        number_of_profiles: 0
+        summary: {}
         _id: _id
     profileCollectionSummary:
       type: object

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1163,7 +1163,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/parameters/dacSummary'
+                  $ref: '#/components/schemas/dacSummary'
                 x-content-type: application/json
         "400":
           description: Bad Request

--- a/nodejs-server/controllers/Dacs.js
+++ b/nodejs-server/controllers/Dacs.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Dacs = require('../service/DacsService');
 
-module.exports.dacList = function dacList (req, res, next) {
-  Dacs.dacList()
+module.exports.dacSummary = function dacSummary (req, res, next) {
+  Dacs.dacSummary()
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Platforms.js
+++ b/nodejs-server/controllers/Platforms.js
@@ -7,6 +7,9 @@ module.exports.platformBGC = function platformBGC (req, res, next) {
   Platforms.platformBGC()
     .then(function (response) {
       utils.writeJson(res, response);
+    }, 
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Platforms.js
+++ b/nodejs-server/controllers/Platforms.js
@@ -3,6 +3,16 @@
 var utils = require('../utils/writer.js');
 var Platforms = require('../service/PlatformsService');
 
+module.exports.platformBGC = function platformBGC (req, res, next) {
+  Platforms.platformBGC()
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};
+
 module.exports.platformList = function platformList (req, res, next, platforms) {
   Platforms.platformList(platforms)
     .then(function (response) {

--- a/nodejs-server/models/summary.js
+++ b/nodejs-server/models/summary.js
@@ -1,0 +1,12 @@
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var summarySchema = Schema(
+    {
+      _id: {type: String, required: true},
+      summary: {type: Schema.Types.Mixed, required: true}
+    }
+  );
+
+module.exports = mongoose.model('summaries', summarySchema, 'summaries');
+

--- a/nodejs-server/service/DacsService.js
+++ b/nodejs-server/service/DacsService.js
@@ -1,5 +1,6 @@
 'use strict';
-const Profile = require('../models/profile');
+const Summary = require('../models/summary');
+const helpers = require('./helpers')
 
 /**
  * Provides summary data for each data assembly center.
@@ -9,24 +10,8 @@ const Profile = require('../models/profile');
 exports.dacSummary = function() {
   return new Promise(function(resolve, reject) {
 
-    const sortMap = new Map();
-    sortMap.set('data_center', 1)
-    sortMap.set('timestamp', -1)
-
-    let dacsummary = [
-        {'$sort': sortMap}, 
-        {'$group': {'_id': '$data_center','number_of_profiles': {'$sum':1}, 'most_recent_date':{'$first':'$timestamp'}}}  
-    ]
-
-    const query = Profile.aggregate(dacsummary)
-
-    query.exec(function (err, dacs) {
-      if (err){
-        reject({"code": 500, "message": "Server error"});
-        return;
-      }
-      resolve(dacs);
-    })
+    const query = Summary.find({"_id":"dacs"})
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
   });
 }
 

--- a/nodejs-server/service/DacsService.js
+++ b/nodejs-server/service/DacsService.js
@@ -4,22 +4,15 @@
 /**
  * Provides summary data for each data assembly center.
  *
- * returns List
+ * returns summary
  **/
 exports.dacSummary = function() {
   return new Promise(function(resolve, reject) {
     var examples = {};
-    examples['application/json'] = [ {
-  "most_recent_date" : "2000-01-23T04:56:07.000+00:00",
-  "dac" : "dac",
-  "number_of_profiles" : 0,
+    examples['application/json'] = {
+  "summary" : { },
   "_id" : "_id"
-}, {
-  "most_recent_date" : "2000-01-23T04:56:07.000+00:00",
-  "dac" : "dac",
-  "number_of_profiles" : 0,
-  "_id" : "_id"
-} ];
+};
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {

--- a/nodejs-server/service/DacsService.js
+++ b/nodejs-server/service/DacsService.js
@@ -2,11 +2,11 @@
 
 
 /**
- * Summary data for all DACs in the database.
+ * Provides summary data for each data assembly center.
  *
  * returns List
  **/
-exports.dacList = function() {
+exports.dacSummary = function() {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/DacsService.js
+++ b/nodejs-server/service/DacsService.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const Profile = require('../models/profile');
 
 /**
  * Provides summary data for each data assembly center.
@@ -8,7 +8,26 @@
  **/
 exports.dacSummary = function() {
   return new Promise(function(resolve, reject) {
-     reject({"code": 501, "message": "Not implemented"});
+
+    const sortMap = new Map();
+    sortMap.set('data_center', 1)
+    sortMap.set('timestamp', -1)
+
+    let dacsummary = [
+        {'$sort': sortMap}, 
+        {'$group': {'_id': '$data_center','number_of_profiles': {'$sum':1}, 'most_recent_date':{'$first':'$timestamp'}}}  
+    ]
+
+    const query = Profile.aggregate(dacsummary)
+
+    query.exec(function (err, dacs) {
+      if (err){
+        reject({"code": 500, "message": "Server error"});
+        return;
+      }
+      resolve(dacs);
+    })
   });
 }
+
 

--- a/nodejs-server/service/PlatformsService.js
+++ b/nodejs-server/service/PlatformsService.js
@@ -1,6 +1,7 @@
 'use strict';
 const Profile = require('../models/profile')
 const helpers = require('./helpers')
+const Summary = require('../models/summary');
 
 /**
  * Provides a list of all Argo platform IDs with BGC data.
@@ -9,7 +10,10 @@ const helpers = require('./helpers')
  **/
 exports.platformBGC = function() {
   return new Promise(function(resolve, reject) {
-     reject({"code": 501, "message": "Not implemented"});
+
+    const query = Summary.find({"_id":"argo_bgc"})
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
+
   });
 }
 

--- a/nodejs-server/service/PlatformsService.js
+++ b/nodejs-server/service/PlatformsService.js
@@ -4,12 +4,15 @@
 /**
  * Provides a list of all Argo platform IDs with BGC data.
  *
- * returns List
+ * returns summary
  **/
 exports.platformBGC = function() {
   return new Promise(function(resolve, reject) {
     var examples = {};
-    examples['application/json'] = [ "", "" ];
+    examples['application/json'] = {
+  "summary" : { },
+  "_id" : "_id"
+};
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {

--- a/nodejs-server/service/PlatformsService.js
+++ b/nodejs-server/service/PlatformsService.js
@@ -2,6 +2,24 @@
 
 
 /**
+ * Provides a list of all Argo platform IDs with BGC data.
+ *
+ * returns List
+ **/
+exports.platformBGC = function() {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = [ "", "" ];
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+
+
+/**
  * Provides a list of platforms with their most recent known report and position.
  *
  * platforms List List of platform IDs

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -353,6 +353,7 @@ const profile_candidate_agg_pipeline = function(startDate,endDate,polygon,box,ce
         aggPipeline.push( {$match: {"geolocation": {$geoWithin: {$geometry: multipolygon[i]}}}} )
       }
     }
+    aggPipeline.push({$sort: {timestamp:-1}})
 
     if(id){
       metadataMatch['_id'] = id

--- a/spec.json
+++ b/spec.json
@@ -691,6 +691,72 @@
                }
             }
          }
+      },
+      "/platforms/bgc": {
+         "get": {
+            "tags": [
+               "platforms"
+            ],
+            "summary": "Provides a list of all Argo platform IDs with BGC data.",
+            "operationId": "platformBGC",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "array",
+                           "items": {
+                              "type": "string"
+                           }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
+      "/dacs": {
+         "get": {
+            "tags": [
+               "dacs"
+            ],
+            "summary": "Provides summary data for each data assembly center.",
+            "operationId": "dacSummary",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "array",
+                           "items": {
+                              "$ref": "#/components/parameters/dacSummary"
+                           }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
       }
    },
    "components": {
@@ -1359,7 +1425,7 @@
                }
             }
          },
-         "dacStub": {
+         "dacSummary": {
             "type": "object",
             "properties": {
                "_id": {

--- a/spec.json
+++ b/spec.json
@@ -740,7 +740,7 @@
                         "schema": {
                            "type": "array",
                            "items": {
-                              "$ref": "#/components/parameters/dacSummary"
+                              "$ref": "#/components/schemas/dacSummary"
                            }
                         }
                      }

--- a/spec.json
+++ b/spec.json
@@ -705,10 +705,7 @@
                   "content": {
                      "application/json": {
                         "schema": {
-                           "type": "array",
-                           "items": {
-                              "type": "string"
-                           }
+                           "$ref": "#/components/schemas/summary"
                         }
                      }
                   }
@@ -738,10 +735,7 @@
                   "content": {
                      "application/json": {
                         "schema": {
-                           "type": "array",
-                           "items": {
-                              "$ref": "#/components/schemas/dacSummary"
-                           }
+                           "$ref": "#/components/schemas/summary"
                         }
                      }
                   }
@@ -1425,21 +1419,14 @@
                }
             }
          },
-         "dacSummary": {
+         "summary": {
             "type": "object",
             "properties": {
                "_id": {
                   "type": "string"
                },
-               "number_of_profiles": {
-                  "type": "integer"
-               },
-               "most_recent_date": {
-                  "type": "string",
-                  "format": "date-time"
-               },
-               "dac": {
-                  "type": "string"
+               "summary": {
+                  "type": "object"
                }
             }
          },


### PR DESCRIPTION
Recreates the routes dropped in #101, and serves static, precomputed responses as defined in https://github.com/argovis/ifremer-sync/pull/17.

Also, reintroduces chronological sort for `/profiles` responses. Examining mongo's `explain` logs on the corresponding pipelines suggests that this doesn't add a `SORT` stage, since the docs are already chronologically sorted in the index used to do the preceding space/time lookup.