### PR TITLE
more flexible request sanitation

### DIFF
--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -83,7 +83,7 @@ exports.drifterSearch = function(startDate,endDate,polygon,multipolygon,id,wmo) 
         return
       } 
     }
-    let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, null, null, multipolygon, id, wmo) // wmo here is a bit kludgy; at time of writing, that argument was intended as Argo platform number, and the sanitation funciton waves through anything with a unique platform number, which is also appropriate for a unique WMO number, but not strictly semantically correct.
+    let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, null, null, multipolygon, id||wmo) 
     if(bailout){
       //request looks huge or malformed, reject it
       reject(bailout)

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -102,7 +102,7 @@ exports.gridselect = function(gridName,presRange,polygon,multipolygon,startDate,
           } 
         }
 
-        let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, null, null, multipolygon, null, null)
+        let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, null, null, multipolygon, null)
         if(bailout){
           //request looks huge, reject it
           reject(bailout)

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -67,7 +67,7 @@ exports.profile = function(startDate,endDate,polygon,box,center,radius,multipoly
       } 
     }
 
-    let bailout = helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)
+    let bailout = helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform||woceline)
     if(bailout){
       //request looks huge or malformed, reject it
       reject(bailout)
@@ -173,7 +173,7 @@ exports.profileList = function(startDate,endDate,polygon,box,center,radius,multi
       } 
     }
 
-    let bailout = helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, null, platform)
+    let bailout = helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, platform||woceline)
     if(bailout){
       //request looks huge or malformed, reject it
       reject(bailout)

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -258,8 +258,9 @@ module.exports.box_sanitation = function(box){
   return box
 }
 
-module.exports.request_sanitation = function(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform){
+module.exports.request_sanitation = function(startDate, endDate, polygon, box, center, radius, multipolygon, allowAll){
   // given some parameters from a requst, decide whether or not to reject; return false == don't reject, return with message / code if do reject
+  // allowAll==true allows the request if it isn't malformed; approriate for requests that have an a-priori small scope, like a single ID, platform or WOCE line.
   const geojsonArea = require('@mapbox/geojson-area');
 
   // basic sanity checks
@@ -298,7 +299,7 @@ module.exports.request_sanitation = function(startDate, endDate, polygon, box, c
   }
 
   // data volume limits
-  if(id || platform){
+  if(allowAll){
     // always allow single ID or platform searches at this point
     return false
   }

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -99,7 +99,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
       });
     });
 
@@ -114,7 +114,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
       });
     }); 
 
@@ -129,7 +129,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.have.property('code', 413) 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.have.property('code', 413) 
       });
     });
 
@@ -144,7 +144,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = null
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
       });
     });
 
@@ -159,12 +159,12 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = 'test-id'
         platform = null
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
       });
     }); 
 
     describe("request_sanitation", function () {
-      it("allows a 20 degree box near the equator for 6 months if an ID is also present", async function () {
+      it("allows a 20 degree box near the equator for 6 months if a platform is also present", async function () {
         startDate = new Date('2020-01-01T00:00:00Z')
         endDate = new Date('2020-07-01T00:00:00Z')
         polygon = null
@@ -174,7 +174,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
         multipolygon = null
         id = null
         platform = 'test-platform'
-        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+        expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
       });
     });   
   }
@@ -190,7 +190,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
       multipolygon = null
       id = null
       platform = null
-      expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id, platform)).to.be.false 
+      expect(helpers.request_sanitation(startDate, endDate, polygon, box, center, radius, multipolygon, id||platform)).to.be.false 
     });
   }); 
 })


### PR DESCRIPTION
Current request sanitation waves through requests with a single platform or profile ID; this PR generalizes this to make semantic sense for any small-scope request, such as one that picks a specific WOCE line for GO-SHIP or WMO number for drifters.