### PR TITLE
drifter refactors, features

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1233,15 +1233,40 @@ paths:
         schema:
           type: string
           example: "[[[0,0],[0,1],[1,1],[1,0],[0,0]],[[0.5,0],[0.5,1],[1.5,1],[1.5,0],[0.5,0]]]"
-      - name: id
+      - name: center
         in: query
-        description: Unique drifter ID to search for.
+        description: center to measure max radius from when defining circular region
+          of interest; must be used in conjunction with query string parameter 'radius'.
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "10,20.1"
+          items:
+            maxItems: 2
+            minItems: 2
+            type: number
+      - name: radius
+        in: query
+        description: km from centerpoint when defining circular region of interest;
+          must be used in conjunction with query string parameter 'center'.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: number
+          example: 50
+      - name: platform
+        in: query
+        description: Unique platform ID to search for.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: "101143"
+          example: "4902911"
       - name: wmo
         in: query
         description: World Meteorological Organization identification number
@@ -1251,6 +1276,16 @@ paths:
         schema:
           type: number
           example: 1300915
+      - name: id
+        in: query
+        description: "ID of individual drifter measurement, formatted [platform_id]_[measurement\
+          \ number starting from 0]"
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          example: 101648_0
       - name: compression
         in: query
         description: Data compression strategy to apply.
@@ -1296,15 +1331,15 @@ paths:
       summary: "Search, reduce and download drifter metadata."
       operationId: drifterMetaSearch
       parameters:
-      - name: id
+      - name: platform
         in: query
-        description: Unique drifter ID to search for.
+        description: Unique platform ID to search for.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: "101143"
+          example: "4902911"
       - name: wmo
         in: query
         description: World Meteorological Organization identification number
@@ -2592,7 +2627,7 @@ components:
       schema:
         type: string
         example: 4902911_0
-    profilePlatform:
+    platformID:
       name: platform
       in: query
       description: Unique platform ID to search for.
@@ -2759,16 +2794,6 @@ components:
         - 1560
         - 1680
         - 1800
-    drifterID:
-      name: id
-      in: query
-      description: Unique drifter ID to search for.
-      required: false
-      style: form
-      explode: true
-      schema:
-        type: string
-        example: "101143"
     wmo:
       name: wmo
       in: query
@@ -2779,3 +2804,14 @@ components:
       schema:
         type: number
         example: 1300915
+    drifterID:
+      name: id
+      in: query
+      description: "ID of individual drifter measurement, formatted [platform_id]_[measurement\
+        \ number starting from 0]"
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: string
+        example: 101648_0

--- a/nodejs-server/controllers/Drifters.js
+++ b/nodejs-server/controllers/Drifters.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Drifters = require('../service/DriftersService');
 
-module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, id, wmo) {
-  Drifters.drifterMetaSearch(id, wmo)
+module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, platform, wmo) {
+  Drifters.drifterMetaSearch(platform, wmo)
     .then(function (response) {
       utils.writeJson(res, response);
     })
@@ -13,8 +13,8 @@ module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, i
     });
 };
 
-module.exports.drifterSearch = function drifterSearch (req, res, next, startDate, endDate, polygon, multipolygon, id, wmo, compression) {
-  Drifters.drifterSearch(startDate, endDate, polygon, multipolygon, id, wmo, compression)
+module.exports.drifterSearch = function drifterSearch (req, res, next, startDate, endDate, polygon, multipolygon, center, radius, platform, wmo, id, compression) {
+  Drifters.drifterSearch(startDate, endDate, polygon, multipolygon, center, radius, platform, wmo, id, compression)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -65,16 +65,13 @@ exports.drifterMetaSearch = function(platform,wmo) {
 exports.drifterSearch = function(startDate,endDate,polygon,multipolygon,center,radius,platform,wmo,id,compression) {
   return new Promise(function(resolve, reject) {
 
-    if(id && wmo){
-      reject({code:400, message: 'Please filter by at most one of id or wmo.'})
-      return
-    }
-
-    let spacetimeMatch = {}
+    let spacetimeMatch = []
+    let proxMatch = []
+    let metadataMatch = []
+    let foreignMatch = []
     let aggPipeline = []
 
-    // spacetime match
-    /// spacetime sanitation
+    // input sanitation & parsing
     if(startDate){
       startDate = new Date(startDate);
     }
@@ -104,71 +101,89 @@ exports.drifterSearch = function(startDate,endDate,polygon,multipolygon,center,r
         return
       } 
     }
-    let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, null, null, multipolygon, id||wmo) 
+    let bailout = helpers.request_sanitation(startDate, endDate, polygon, null, center, radius, multipolygon, platform||wmo||id) 
     if(bailout){
       //request looks huge or malformed, reject it
       reject(bailout)
       return
     }
-    /// spacetime agg stage construction
-    if (startDate && endDate){
-      spacetimeMatch['timestamp'] = {$gte: startDate, $lte: endDate}
-    } else if (startDate){
-      spacetimeMatch['timestamp'] = {$gte: startDate}
-    } else if (endDate){
-      spacetimeMatch['timestamp'] = {$lte: endDate}
-    }
-    if(polygon) {
-      spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: polygon}}
-    }
-    if(multipolygon){
-      multipolygon.sort((a,b)=>{geojsonArea.geometry(a) - geojsonArea.geometry(b)}) // smallest first to minimize size of unindexed geo search
-      spacetimeMatch['geolocation'] = {$geoWithin: {$geometry: multipolygon[0]}}
-    }
-    aggPipeline.push({$match: spacetimeMatch})
-    // zoom in on subsequent polygon regions; will be unindexed.
-    if(multipolygon && multipolygon.length > 1){
-      for(let i=1; i<multipolygon.length; i++){
-        aggPipeline.push( {$match: {"geolocation": {$geoWithin: {$geometry: multipolygon[i]}}}} )
-      }
-    }
-    aggPipeline.push({$sort: {timestamp:-1}})
 
-    // look up metadata first if searching by wmo and then drifters
+    // construct match stages as required
+    /// prox match construction
+    if(center && radius) {
+      proxMatch.push({$geoNear: {key: 'geolocation', near: {type: "Point", coordinates: [center[0], center[1]]}, maxDistance: 1000*radius, distanceField: "distcalculated"}}) 
+      proxMatch.push({ $unset: "distcalculated" })
+    }
+
+    /// spacetime match construction
+    if(startDate || endDate || polygon || multipolygon){
+      spacetimeMatch[0] = {$match: {}}
+      if (startDate && endDate){
+        spacetimeMatch[0]['$match']['timestamp'] = {$gte: startDate, $lte: endDate}
+      } else if (startDate){
+        spacetimeMatch[0]['$match']['timestamp'] = {$gte: startDate}
+      } else if (endDate){
+        spacetimeMatch[0]['$match']['timestamp'] = {$lte: endDate}
+      }
+      if(polygon) {
+        spacetimeMatch[0]['$match']['geolocation'] = {$geoWithin: {$geometry: polygon}}
+      }
+      if(multipolygon){
+        multipolygon.sort((a,b)=>{geojsonArea.geometry(a) - geojsonArea.geometry(b)}) // smallest first to minimize size of unindexed geo search
+        spacetimeMatch[0]['$match']['geolocation'] = {$geoWithin: {$geometry: multipolygon[0]}}
+      }
+      // zoom in on subsequent polygon regions; will be unindexed.
+      if(multipolygon && multipolygon.length > 1){
+        for(let i=1; i<multipolygon.length; i++){
+          spacetimeMatch.push( {$match: {"geolocation": {$geoWithin: {$geometry: multipolygon[i]}}}} )
+        }
+      }
+      spacetimeMatch.push({$sort: {timestamp:-1}})
+    }
+
+    /// metadata match contruction
+    if(platform || id){
+      metadataMatch[0] = {$match: {'metadata': platform, '_id': id}}
+    }
+
+    /// foreign table match construction
     if(wmo){
-      let query = Drifter['drifterMeta'].aggregate([{$match: {'WMO': wmo}}])
+      foreignMatch[0] = {$match: {'WMO': wmo}}
+    }
+
+    if(foreignMatch.length > 0){ // want to leverage indexes of both collections; index search the foreign table first, and use the result to construct a pipeline stage for the main table, which can be inserted as optimal.
+      let query = Drifter['drifterMeta'].aggregate(foreignMatch)
       query.exec(function (err, driftermeta) {
         if (err){
           reject({"code": 500, "message": "Server error"});
           return;
         }
-        let ids = new Set(driftermeta.map(x => x['_id']))
+        let platforms = new Set(driftermeta.map(x => x['_id']))
 
-        aggPipeline.unshift({$match:{'metadata':{$in:Array.from(ids)}}}) 
+        aggPipeline = aggPipeline.concat(proxMatch) // mongo requires this to come first if present
+        aggPipeline = aggPipeline.concat(metadataMatch)
+        aggPipeline.push({$match:{'metadata':{$in:Array.from(platforms)}}})
+        aggPipeline = aggPipeline.concat(spacetimeMatch)
+
         query = Drifter['drifters'].aggregate(aggPipeline);
         if(compression){
           query.exec(helpers.queryCallback.bind(null,null,resolve, reject)) 
         } else {
           query.exec(helpers.queryCallback.bind(null,inflateDrifters, resolve, reject)) 
         }
-      })
-    } else if(id) {
-      aggPipeline.unshift({$match: {'metadata': id}})
-      let query = Drifter['drifters'].aggregate(aggPipeline);
-      if(compression){
-        query.exec(helpers.queryCallback.bind(null,null,resolve, reject)) 
-      } else {
-        query.exec(helpers.queryCallback.bind(null,inflateDrifters, resolve, reject)) 
-      }
+      })      
     } else {
-      let query = Drifter['drifters'].aggregate(aggPipeline);
-      if(compression){
-        query.exec(helpers.queryCallback.bind(null,null,resolve, reject)) 
-      } else {
-        query.exec(helpers.queryCallback.bind(null,inflateDrifters, resolve, reject)) 
-      }
-    }
+        aggPipeline = aggPipeline.concat(proxMatch) // mongo requires this to come first if present
+        aggPipeline = aggPipeline.concat(metadataMatch)
+        aggPipeline = aggPipeline.concat(spacetimeMatch)
 
+        let query = Drifter['drifters'].aggregate(aggPipeline);
+        if(compression){
+          query.exec(helpers.queryCallback.bind(null,null,resolve, reject)) 
+        } else {
+          query.exec(helpers.queryCallback.bind(null,inflateDrifters, resolve, reject)) 
+        }
+    }
   });
 }
 
@@ -183,7 +198,7 @@ exports.drifterVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
     let key = ''
     if(parameter == 'wmo') key = 'WMO'
-    else if(parameter == 'id') key = '_id'
+    else if(parameter == 'platform') key = '_id'
 
     Drifter['drifterMeta'].find().distinct(key, function (err, vocab) {
       if (err){

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -32,7 +32,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
 
     let metaMatch = {}
 
-    if(id){
+    if(platform){
       metaMatch['_id'] = id
     }
 

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -4,11 +4,11 @@
 /**
  * Search, reduce and download drifter metadata.
  *
- * id String Unique drifter ID to search for. (optional)
+ * platform String Unique platform ID to search for. (optional)
  * wmo BigDecimal World Meteorological Organization identification number (optional)
  * returns List
  **/
-exports.drifterMetaSearch = function(id,wmo) {
+exports.drifterMetaSearch = function(platform,wmo) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {
@@ -80,12 +80,15 @@ exports.drifterMetaSearch = function(id,wmo) {
  * endDate Date ISO 8601 UTC date-time formatted string indicating the end of the time period of interest. (optional)
  * polygon String array of [lon, lat] vertices describing a polygon bounding the region of interest; final point must match initial point (optional)
  * multipolygon String array of polygon regions; region of interest is taken as the intersection of all listed polygons. (optional)
- * id String Unique drifter ID to search for. (optional)
+ * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
+ * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
+ * platform String Unique platform ID to search for. (optional)
  * wmo BigDecimal World Meteorological Organization identification number (optional)
+ * id String ID of individual drifter measurement, formatted [platform_id]_[measurement number starting from 0] (optional)
  * compression String Data compression strategy to apply. (optional)
  * returns List
  **/
-exports.drifterSearch = function(startDate,endDate,polygon,multipolygon,id,wmo,compression) {
+exports.drifterSearch = function(startDate,endDate,polygon,multipolygon,center,radius,platform,wmo,id,compression) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/helpers.js
+++ b/nodejs-server/service/helpers.js
@@ -268,7 +268,7 @@ module.exports.request_sanitation = function(startDate, endDate, polygon, box, c
     return {"code": 400, "message": "Please request only one of box, polygon, center or multipolygon."} 
   }
   if((center && !radius) || (!center && radius)){
-    return {"code": 400, "message": "Please specify both radius and center to filter for profiles less than <radius> km from <center>."}
+    return {"code": 400, "message": "Please specify both radius and center to filter for data less than <radius> km from <center>."}
   }
 
   // geo size limits - mongo doesn't like huge geoWithins

--- a/spec.json
+++ b/spec.json
@@ -427,7 +427,7 @@
                   "$ref": "#/components/parameters/profileID"
                },
                {
-                  "$ref": "#/components/parameters/profilePlatform"
+                  "$ref": "#/components/parameters/platformID"
                },
                {
                   "$ref": "#/components/parameters/presRange"
@@ -513,7 +513,7 @@
                   "$ref": "#/components/parameters/woceline" 
                },
                {
-                  "$ref": "#/components/parameters/profilePlatform"
+                  "$ref": "#/components/parameters/platformID"
                },
                {
                   "$ref": "#/components/parameters/presRange"
@@ -777,10 +777,19 @@
                   "$ref": "#/components/parameters/multipolygon"
                },
                {
-                  "$ref": "#/components/parameters/drifterID"
+                  "$ref": "#/components/parameters/center"
+               },
+               {
+                  "$ref": "#/components/parameters/radius"
+               },
+               {
+                  "$ref": "#/components/parameters/platformID"
                },
                {
                   "$ref": "#/components/parameters/wmo"
+               },
+               {
+                  "$ref": "#/components/parameters/drifterID"
                },
                {
                   "$ref": "#/components/parameters/compression"
@@ -821,7 +830,7 @@
             "operationId": "drifterMetaSearch",
             "parameters": [
                {
-                  "$ref": "#/components/parameters/drifterID"
+                  "$ref": "#/components/parameters/platformID"
                },
                {
                   "$ref": "#/components/parameters/wmo"
@@ -1938,7 +1947,7 @@
                "example": "4902911_0"
             }
          },
-         "profilePlatform": {
+         "platformID": {
             "in": "query",
             "name": "platform",
             "description": "Unique platform ID to search for.",
@@ -2098,15 +2107,6 @@
                ]
             }
          },
-         "drifterID": {
-            "in": "query",
-            "name": "id",
-            "description": "Unique drifter ID to search for.",
-            "schema": {
-               "type": "string",
-               "example": "101143"
-            }
-         },
          "wmo": {
             "in": "query",
             "name": "wmo",
@@ -2114,6 +2114,15 @@
             "schema": {
                "type": "number",
                "example": 1300915
+            }
+         },
+         "drifterID": {
+            "in": "query",
+            "name": "id",
+            "description": "ID of individual drifter measurement, formatted [platform_id]_[measurement number starting from 0]",
+            "schema": {
+               "type": "string",
+               "example": "101648_0"
             }
          }
       },


### PR DESCRIPTION
 - support prox search for drifters
 - keep semantics about 'platforms' the same for drifters and argo: drifter platform IDs are the `ID` variable from the upstream netcdf: there are about 18k of them, they make the unique key `_id` for `drifterMeta` and the corresponding foreign key `metadata` in `drifters`.
 - add a meaningful `_id` in `drifters` equal to `<platform id>_<measurement number>`, analogous to profiles
 - refactor the logic of `/drifters` to be a bit more logical and easier to follow.