### PR TITLE
base image patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM argovis/api:base-220531
+FROM argovis/api:base-220606
 COPY nodejs-server /app
 RUN cp mods/express.app.config.js /app/node_modules/oas3-tools/dist/middleware/express.app.config.js
 CMD npm start

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -1,7 +1,7 @@
-FROM node:17.8.0 as build
+FROM node:17.9.0 as build
 WORKDIR /app
 COPY nodejs-server/package.json .
 RUN npm install
 RUN apt-get update -y
-RUN apt-get install -y zlib1g/stable-security subversion/stable-security openssl/stable-security ldap-utils/stable-security
+#RUN apt-get install -y zlib1g/stable-security subversion/stable-security openssl/stable-security ldap-utils/stable-security
 


### PR DESCRIPTION
scanner is still complaining about CVE-2022-1292 from node 17.8.0.