### PR TITLE
platform / id debug

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1396,7 +1396,7 @@ paths:
           type: string
           enum:
           - wmo
-          - id
+          - platform
       responses:
         "200":
           description: OK

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -33,7 +33,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
     let metaMatch = {}
 
     if(platform){
-      metaMatch['_id'] = id
+      metaMatch['_id'] = platform
     }
 
     if(wmo){

--- a/spec.json
+++ b/spec.json
@@ -877,7 +877,7 @@
                   "description": "/drifters query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["wmo", "id"]
+                     "enum": ["wmo", "platform"]
                   }
                }
             ],

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -71,6 +71,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
         const response = await request.get("/drifters?id=101143_0").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
+    }); 
+
+    describe("GET /drifters/meta", function () {
+      it("fetch drifter metadata by platform number", async function () {
+        const response = await request.get("/drifters/meta?platform=101143").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(1);
+      });
     });     
   }
 })


### PR DESCRIPTION
User-facing parameter for searching for a platform by platform number is `platform` - correctly map this onto `_id` when searching the metadata collection. Thanks to @philippemiron for pointing this out!