### PR TITLE
Server stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM argovis/api:base-220712
+FROM argovis/api:base-220815
 COPY nodejs-server /app
 RUN cp mods/express.app.config.js /app/node_modules/oas3-tools/dist/middleware/express.app.config.js
 CMD npm start

--- a/nodejs-server/controllers/Drifters.js
+++ b/nodejs-server/controllers/Drifters.js
@@ -2,12 +2,11 @@
 
 var utils = require('../utils/writer.js');
 var Drifters = require('../service/DriftersService');
+var helpers = require('../helpers/helpers')
 
 module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, platform, wmo) {
-  Drifters.drifterMetaSearch(platform, wmo)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Drifters.drifterMetaSearch(res,platform, wmo)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })
@@ -17,10 +16,8 @@ module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, p
 };
 
 module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, data) {
-  Drifters.drifterSearch(id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, data)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Drifters.drifterSearch(res,id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, data)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -2,12 +2,11 @@
 
 var utils = require('../utils/writer.js');
 var Grid = require('../service/GridService');
+var helpers = require('../helpers/helpers')
 
 module.exports.findgrid = function findgrid (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, compression, data, presRange, gridName) {
-  Grid.findgrid(gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, data, presRange)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Grid.findgrid(res,gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, data, presRange)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })
@@ -17,10 +16,8 @@ module.exports.findgrid = function findgrid (req, res, next, id, startDate, endD
 };
 
 module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
-  Grid.findgridMeta(id)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Grid.findgridMeta(res,id)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -5,10 +5,8 @@ var Profiles = require('../service/ProfilesService');
 var helpers = require('../helpers/helpers')
 
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
-  Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Profiles.findArgo(res, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })
@@ -18,10 +16,8 @@ module.exports.findArgo = function findArgo (req, res, next, id, startDate, endD
 };
 
 module.exports.findArgometa = function findArgometa (req, res, next, id, platform) {
-  Profiles.findArgometa(id, platform)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Profiles.findArgometa(res, id, platform)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -32,7 +32,7 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
 
 module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
   Profiles.findGoship(res, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
-    .then(pipefittings => helpers.pipeline.bind(null, res)(pipefittings),
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })
@@ -41,12 +41,9 @@ module.exports.findGoship = function findGoship (req, res, next, id, startDate, 
     });
 };
 
-
 module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {
   Profiles.findGoshipmeta(id, woceline, cchdo_cruise)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -3,8 +3,7 @@
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
 var JSONStream = require('JSONStream')
-const { pipeline } = require('node:stream/promises');
-var stream = require("stream");
+const { pipeline } = require('stream');
 
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
   Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
@@ -33,63 +32,28 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
 };
 
 module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
-  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
-
-    .then(cursor => {
-      cursor.pipe(JSONStream.stringify())
-            .pipe(res.type('json'))
+  Profiles.findGoship(res, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
+    .then(pipefittings => {
+      pipeline(
+        pipefittings[0],
+        pipefittings[1],
+        JSONStream.stringify(),
+        res.type('json'),
+        (err) => {
+          if(err){
+            console.log(err.message)
+          }
+        }
+      )
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
-
-
-    // .then(stream => {
-    //   stream.pipe(JSONStream.stringify())
-    //         .pipe(res.type('json'))
-    // })
-
-
-    // .then(stream => {
-    //   stream.pipe(JSONStream.stringifyObject())
-    //         .pipe(res.type('json'))
-    // })
-
-
-    // .then(stream => {
-    //   res.type('json');
-    //   async function streamDocs(stream){
-    //     let counter = 0
-    //     for await (const chunk of stream){
-    //       res.write({'potato': counter++})
-    //     }   
-    //   }
-    //   streamDocs(stream)
-    // })
-
-    // .then(stream => {
-    //   stream.pipe(JSONStream.stringify())
-    //         .pipe(res.type('json'))
-    // })
-
-    // .then(cursor => {
-    //   cursor.on('data', function(doc) { console.log(doc); }).on('end', function() { console.log('Done!'); });
-    // })
-
-    // .then(cursor => {
-    //   cursor.next(function(error, doc) {
-    //     console.log(doc);
-    //   });
-    // })  
-
-
-    // .then(function (response) {
-    //   utils.writeJson(res, response);
-    // },
-    // function (response) {
-    //   utils.writeJson(res, response, response.code);
-    // })
-    // .catch(function (response) {
-    //   utils.writeJson(res, response);
-    // });
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
 };
+
 
 module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {
   Profiles.findGoshipmeta(id, woceline, cchdo_cruise)

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -2,8 +2,7 @@
 
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
-var JSONStream = require('JSONStream')
-const { pipeline } = require('stream');
+var helpers = require('../helpers/helpers')
 
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
   Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
@@ -33,19 +32,7 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
 
 module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
   Profiles.findGoship(res, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
-    .then(pipefittings => {
-      pipeline(
-        pipefittings[0],
-        pipefittings[1],
-        JSONStream.stringify(),
-        res.type('json'),
-        (err) => {
-          if(err){
-            console.log(err.message)
-          }
-        }
-      )
-    },
+    .then(pipefittings => helpers.pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -37,7 +37,7 @@ module.exports.findGoship = function findGoship (req, res, next, id, startDate, 
 
     .then(cursor => {
       cursor.pipe(JSONStream.stringify())
-      cursor.pipe(res.type('json'))
+            .pipe(res.type('json'))
     })
 
 

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -2,6 +2,9 @@
 
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
+var JSONStream = require('JSONStream')
+const { pipeline } = require('node:stream/promises');
+var stream = require("stream");
 
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
   Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
@@ -31,15 +34,61 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
 
 module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
   Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
-    function (response) {
-      utils.writeJson(res, response, response.code);
+
+    .then(cursor => {
+      cursor.pipe(JSONStream.stringify())
+      cursor.pipe(res.type('json'))
     })
-    .catch(function (response) {
-      utils.writeJson(res, response);
-    });
+
+
+    // .then(stream => {
+    //   stream.pipe(JSONStream.stringify())
+    //         .pipe(res.type('json'))
+    // })
+
+
+    // .then(stream => {
+    //   stream.pipe(JSONStream.stringifyObject())
+    //         .pipe(res.type('json'))
+    // })
+
+
+    // .then(stream => {
+    //   res.type('json');
+    //   async function streamDocs(stream){
+    //     let counter = 0
+    //     for await (const chunk of stream){
+    //       res.write({'potato': counter++})
+    //     }   
+    //   }
+    //   streamDocs(stream)
+    // })
+
+    // .then(stream => {
+    //   stream.pipe(JSONStream.stringify())
+    //         .pipe(res.type('json'))
+    // })
+
+    // .then(cursor => {
+    //   cursor.on('data', function(doc) { console.log(doc); }).on('end', function() { console.log('Done!'); });
+    // })
+
+    // .then(cursor => {
+    //   cursor.next(function(error, doc) {
+    //     console.log(doc);
+    //   });
+    // })  
+
+
+    // .then(function (response) {
+    //   utils.writeJson(res, response);
+    // },
+    // function (response) {
+    //   utils.writeJson(res, response, response.code);
+    // })
+    // .catch(function (response) {
+    //   utils.writeJson(res, response);
+    // });
 };
 
 module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -42,7 +42,7 @@ module.exports.findGoship = function findGoship (req, res, next, id, startDate, 
 };
 
 module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {
-  Profiles.findGoshipmeta(id, woceline, cchdo_cruise)
+  Profiles.findGoshipmeta(res, id, woceline, cchdo_cruise)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);

--- a/nodejs-server/controllers/Tc.js
+++ b/nodejs-server/controllers/Tc.js
@@ -2,12 +2,11 @@
 
 var utils = require('../utils/writer.js');
 var Tc = require('../service/TcService');
+var helpers = require('../helpers/helpers')
 
 module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, name, compression, data) {
-  Tc.findTC(id, startDate, endDate, polygon, multipolygon, center, radius, name, compression, data)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Tc.findTC(res, id, startDate, endDate, polygon, multipolygon, center, radius, name, compression, data)
+    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })
@@ -17,10 +16,8 @@ module.exports.findTC = function findTC (req, res, next, id, startDate, endDate,
 };
 
 module.exports.findTCmeta = function findTCmeta (req, res, next, id, name) {
-  Tc.findTCmeta(id,name)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    },
+  Tc.findTCmeta(res,id,name)
+   .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
     })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -840,23 +840,24 @@ module.exports.cost = function(url, c, cellprice, metaDiscount, maxbulk){
   }
 
   /// determine path steps
-  let path = url.split('?')[0].split('/').slice(3)
+  let path = url.split('?')[0].split('/').slice(1)
 
   /// tokenize query string
   let qString = new URLSearchParams(url.split('?')[1]);
 
   /// handle standardized routes
   let standard_routes = ['argo', 'goship', 'drifters', 'tc', 'grids']
+
   if(standard_routes.includes(path[0])){
     //// core data routes
     if(path.length==1 || (path[0]=='grids' && path.length==2)){
       ///// any query parameter that specifies a particular record or small set of records can get waived through
-      if(qString.get('id') || qString.get('platform') || qString.get('wmo') || qString.get('name')){
+      if(qString.get('id') || qString.get('wmo') || qString.get('name')){
         c = 1
       }
 
       //// query parameters that specify a larger but still circumscribed number of records
-      else if(qString.get('woceline') || qString.get('cchdo_cruise')){
+      else if(qString.get('woceline') || qString.get('cchdo_cruise') || qString.get('platform') ){
         c = 10
       }
 

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -377,7 +377,7 @@ module.exports.datatable_match = function(model, params, local_filter, foreign_d
   // set up aggregation and return promise to evaluate:
   let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch)
 
-  return model.aggregate(aggPipeline).exec()
+  return model.aggregate(aggPipeline).cursor()
 }
 
 module.exports.postprocess = function(pp_params, search_result){
@@ -531,6 +531,158 @@ module.exports.postprocess = function(pp_params, search_result){
 
   return polished
 
+}
+
+module.exports.postprocess = function(chunk, metadata, pp_params){
+  // <chunk>: raw data table document
+  // <metadata>: metadata doc corresponding to this chunk
+  // <pp_params>: kv which defines level filtering, data selection and compression decisions
+  // returns chunk mutated into its final, user-facing form
+  // or return false to drop this item from the stream
+
+  // declare some variables at scope
+  let keys = []       // data keys to keep when filtering down data
+  let notkeys = []    // data ketys that disqualify a document if present
+  let my_meta = null  // metadata document corresponding to chunk
+  let coerced_pressure = false
+  let metadata_only = false
+  
+  // determine which data keys should be kept or tossed, if necessary
+  if(pp_params.data){
+    keys = pp_params.data.filter(e => e.charAt(0)!='~')
+    notkeys = pp_params.data.filter(e => e.charAt(0)=='~').map(k => k.substring(1))
+    if(keys.includes('metadata-only')){
+      metadata_only = true
+      keys.splice(keys.indexOf('metadata-only'))
+    }
+  }
+
+  // identify data_keys and units, could be on chunk or metadata
+  let dk = null
+  let u = null
+  if(chunk.hasOwnProperty('data_keys')) {
+    dk = chunk.data_keys  
+    u = chunk.units
+  }
+  else{
+    dk = metadata.data_keys
+    u = metadata.units
+  }
+
+  // bail out on this document if it contains any ~keys:
+  if(dk.some(item => notkeys.includes(item))) return false
+
+  // force return of pressure for anything that has a pressure data key
+  if(dk.includes('pressure') && !keys.includes('pressure')){
+    keys.push('pressure')
+    coerced_pressure = true
+  }
+
+  // turn upstream units into a lookup table by data_key
+  let units = {}
+  for(let k=0; k<dk.length; k++){
+    units[dk[k]] = u[k]
+  }
+
+  // reinflate data arrays as a dictionary keyed by depth, and only keep requested data
+  let reinflated_levels = {}
+  let metalevels = null
+  if(metadata.hasOwnProperty('levels')){
+    metalevels = metadata.levels // relevant for grids
+  } else if (!dk.includes('pressure')){
+    metalevels = [0] // some sea surface datasets have no levels metadata and no profile-like pres key, since they're all implicitly single-level pres=0 surface measurements
+  }
+  for(let j=0; j<chunk.data.length; j++){ // loop over levels
+    let reinflate = {}
+    for(k=0; k<chunk.data[j].length; k++){ // loop over data variables
+      if( (keys.includes(dk[k]) || keys.includes('all')) && !isNaN(chunk.data[j][k]) && chunk.data[j][k] !== null){ // ie only keep data that was actually requested, and which actually exists
+        reinflate[dk[k]] = chunk.data[j][k]
+      }
+    }
+    if(Object.keys(reinflate).length > (coerced_pressure ? 1 : 0)){ // ie only keep levels that retained some data other than a coerced pressure record
+      let lvl = metalevels ? metalevels[j] : reinflate.pressure
+      reinflated_levels[lvl] = reinflate
+    }
+  }
+
+  // filter by presRange
+  let levels = []
+  if(pp_params.presRange){
+    levels = Object.keys(reinflated_levels).filter(k => Number(k) >= pp_params.presRange[0] && Number(k) <= pp_params.presRange[1])
+  } else {
+    levels = Object.keys(reinflated_levels)
+  }
+  levels = levels.map(n=>Number(n)).sort((a,b)=>a-b)
+
+  // translate level-keyed dictionary back to a sorted list of per-level dictionaries
+  if(metalevels && pp_params.presRange){
+    /// need to make a levels property on the data document that overrides the levels property on the metadata doc if level filtering has happened, for grid-like objects
+    chunk.levels = levels
+  }
+  chunk.data = levels.map(k=>reinflated_levels[String(k)])
+
+  // if we wanted data and none is left, abandon this document
+  if(keys.length>(coerced_pressure ? 1 : 0) && chunk.data.length==0) return false
+
+  // drop data on metadata only requests
+  if(!pp_params.data || metadata_only){
+    delete chunk.data
+    delete chunk.levels
+  }
+
+  // manage data_keys and units
+  if(keys.includes('all') && !metadata_only){
+    chunk.data_keys = dk
+    chunk.units = units
+  }
+  else if( (keys.length > (coerced_pressure ? 1 : 0)) && !metadata_only){
+    chunk.data_keys = keys
+    chunk.units = units
+    for(const prop in units){
+      if(!keys.includes(prop)) delete chunk.units[prop]
+    }
+  }
+
+  // deflate data if requested
+  if(pp_params.compression && pp_params.data && !metadata_only){
+    chunk.data = chunk.data.map(x => {
+      let lvl = []
+      for(let ii=0; ii<chunk.data_keys.length; ii++){
+        if(x.hasOwnProperty(chunk.data_keys[ii])){
+          lvl.push(x[chunk.data_keys[ii]])
+        } else {
+          lvl.push(null)
+        }
+      }
+      return lvl
+    })
+    chunk.units = chunk.data_keys.map(x => chunk.units[x])
+  }
+
+  return chunk
+}
+
+module.exports.locate_meta = function(meta_id, meta_list, meta_model){
+  // <meta_id>: id of meta document of interest
+  // <meta_list>: current array of fetched meta docs
+  // <meta_model>: collection model tp go looking in
+  // return a promise that resolves to the metadata record sought.
+
+  let my_meta = undefined
+  if(meta_list){
+    console.log(meta_list.length)
+    my_meta = meta_list.find(x => x._id == meta_id)
+  } else {
+    meta_list = []
+    console.log(0)
+  }
+  if(typeof my_meta !== 'undefined'){
+    return new Promise(function(resolve, reject){resolve(my_meta)})
+  } else {
+    // go looking in mongo
+    let metaquery = meta_model.findOne({ _id: meta_id });
+    return metaquery.exec();
+  }
 }
 
 module.exports.meta_lookup = function(meta_model, data_docs){

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -648,7 +648,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params){
   if(metadata.hasOwnProperty('levels')){
     metalevels = metadata.levels // relevant for grids
   } else if (!dk.includes('pressure')){
-    metalevels = [0] // some sea surface datasets have no levels metadata and no profile-like pres key, since they're all implicitly single-level pres=0 surface measurements
+    metalevels = [0] // some sea surface datasets have no levels metadata and no profile-like pressure key, since they're all implicitly single-level pres=0 surface measurements
   }
   for(let j=0; j<chunk.data.length; j++){ // loop over levels
     let reinflate = {}
@@ -785,7 +785,7 @@ module.exports.locate_meta = function(meta_id, meta_list, meta_model){
     return new Promise(function(resolve, reject){resolve(my_meta)})
   } else {
     // go looking in mongo
-    let metaquery = meta_model.findOne({ _id: meta_id });
+    let metaquery = meta_model.findOne({ _id: meta_id }).lean();
     return metaquery.exec();
   }
 }

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -333,7 +333,7 @@ module.exports.datatable_match = function(model, params, local_filter, foreign_d
   // <params> the return object from parameter_sanitization,
   // <local_filter> a custom set of aggregation pipeline steps to be applied to the data collection reffed by <model>,
   // and <foreign_docs>, an array of documents matching a query on the metadata collection which should constrain which data collection docs we return,
-  // return a cursor over that which matches the above
+  // return a promise to search <model> for all of the above.
 
   let spacetimeMatch = []
   let proxMatch = []
@@ -739,6 +739,28 @@ module.exports.post_xform = function(metaModel, pp_params, search_result, res){
             }
             next()
           })
+    }
+  });
+  
+  postprocess._flush = function(callback){
+    if(nDocs == 0){
+      res.status(404)
+    }
+    return callback()
+  }
+
+  return postprocess
+}
+
+module.exports.meta_xform = function(res){
+  // transform stream that only looks for 404s
+
+  let nDocs = 0
+  const postprocess = new Transform({
+    objectMode: true,
+    transform(chunk, encoding, next){
+      this.push(chunk)
+      next()
     }
   });
   

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -1,5 +1,7 @@
 const geojsonArea = require('@mapbox/geojson-area');
 const Transform = require('stream').Transform
+const { pipeline } = require('stream');
+const JSONStream = require('JSONStream')
 
 module.exports = {}
 
@@ -914,6 +916,19 @@ module.exports.geoarea = function(polygon, multipolygon, radius){
   return geospan
 }
 
+module.exports.pipeline = function(res, pipefittings){
+  pipeline(
+    pipefittings[0],
+    pipefittings[1],
+    JSONStream.stringify(),
+    res.type('json'),
+    (err) => {
+      if(err){
+        console.log(err.message)
+      }
+    }
+  )
+}
 
 
 

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -369,7 +369,7 @@ module.exports.datatable_match = function(model, params, local_filter, foreign_d
   }
 
   /// construct filter for matching metadata docs if required
-  if(foreign_docs){
+  if(foreign_docs.length > 0 && foreign_docs[0]._id !== null){
     let metaIDs = new Set(foreign_docs.map(x => x['_id']))
     foreignMatch.push({$match:{'metadata':{$in:Array.from(metaIDs)}}})
   }
@@ -668,14 +668,7 @@ module.exports.locate_meta = function(meta_id, meta_list, meta_model){
   // <meta_model>: collection model tp go looking in
   // return a promise that resolves to the metadata record sought.
 
-  let my_meta = undefined
-  if(meta_list){
-    console.log(meta_list.length)
-    my_meta = meta_list.find(x => x._id == meta_id)
-  } else {
-    meta_list = []
-    console.log(0)
-  }
+  let my_meta = meta_list.find(x => x._id == meta_id)
   if(typeof my_meta !== 'undefined'){
     return new Promise(function(resolve, reject){resolve(my_meta)})
   } else {

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -916,10 +916,9 @@ module.exports.geoarea = function(polygon, multipolygon, radius){
   return geospan
 }
 
-module.exports.pipeline = function(res, pipefittings){
+module.exports.data_pipeline = function(res, pipefittings){
   pipeline(
-    pipefittings[0],
-    pipefittings[1],
+    ...pipefittings,
     JSONStream.stringify(),
     res.type('json'),
     (err) => {

--- a/nodejs-server/middleware/ratelimiter/tokenbucket.js
+++ b/nodejs-server/middleware/ratelimiter/tokenbucket.js
@@ -18,9 +18,9 @@ module.exports.tokenbucket = function (req, res, next) {
 	let bucketsize = 100
 	let tokenrespawntime = 1000 // ms to respawn one token
 	let requestCost = 1 //default cost, for metadata-only requests
-	let cellprice = 0.001 // token cost of 1 sq deg day
+	let cellprice = 0.0001 // token cost of 1 sq deg day
 	let metaDiscount = 100 // scaledown factor to discount metadata-only request by relative to data requests
-	let maxbulk = 100000 // maximum allowed size of ndays x area[sq km]/13000sqkm; set to prevent OOM crashes
+	let maxbulk = 1000000 // maximum allowed size of ndays x area[sq km]/13000sqkm; set to prevent OOM crashes
 	let argokey = 'guest'
 	if(req.headers['x-argokey']){
 		argokey = req.headers['x-argokey']
@@ -63,7 +63,7 @@ module.exports.tokenbucket = function (req, res, next) {
 		else if(tokensnow >= 0){
 			hsetAsync(userbucket.key, "ntokens", tokensnow-requestCost, "lastUpdate", t).then(next())
 		} else {
-			throw({"code": 429, "message": "You have temporarily exceeded your API request limit. Try again in a minute, but limit your requests to small bursts, or wait a few seconds between requests long term."})
+			throw({"code": 429, "message": "You have temporarily exceeded your API request limit. You will be able to issue another request in "+String(-1*tokensnow)+" seconds. Long term, requests like the one you just made can be made every "+String(requestCost)+" seconds."})
 		}
 	})
 	.catch(err => {

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -22,6 +22,7 @@
     "moment": "^2.24.0",
     "mongoose": "^6.2.10",
     "oas3-tools": "^2.2.3",
-    "redis": "^3.1.2"
+    "redis": "^3.1.2",
+    "JSONStream": "1.3.5"
   }
 }

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -214,10 +214,9 @@ exports.findGoshipmeta = function(id,woceline,cchdo_cruise) {
     Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
     const query = goship['goshipMeta'].aggregate([{$match:match}]);
-    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
+    resolve([query.cursor()])
   });
 }
-
 
 /**
  * List all possible values for certain tc query string parameters

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -4,6 +4,7 @@ const goship = require('../models/goship');
 const argo = require('../models/argo');
 const helpers = require('../helpers/helpers')
 const geojsonArea = require('@mapbox/geojson-area');
+const Transform = require('stream').Transform
 
 /**
  * Argo search and filter.
@@ -199,6 +200,23 @@ exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,r
   });
 }
 
+exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,compression,data,presRange) {
+  return new Promise(function(resolve, reject) {
+
+    const xform = new Transform({
+      objectMode: true,
+      transform(chunk, encoding, next){
+        this.push({...chunk.toJSON(), potato:9999})
+        next()
+      }
+    })
+    
+    //resolve(goship['goship'].find({'metadata':{'$in':['453_m0','1116_m0']}}).cursor().pipe(xform))
+    //resolve(goship['goship'].find({'metadata':{'$in':['453_m0','1116_m0']}}).cursor())
+    resolve(goship['goship'].find({'metadata':{'$in':['453_m0','1116_m0']}}).lean().cursor())
+
+  })
+}
 
 /**
  * GO-SHIP metadata search and filter.

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -204,7 +204,7 @@ exports.findGoship = function(res, id,startDate,endDate,polygon,multipolygon,cen
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * returns List
  **/
-exports.findGoshipmeta = function(id,woceline,cchdo_cruise) {
+exports.findGoshipmeta = function(res, id,woceline,cchdo_cruise) {
   return new Promise(function(resolve, reject) {
     let match = {
         '_id': id,
@@ -214,7 +214,8 @@ exports.findGoshipmeta = function(id,woceline,cchdo_cruise) {
     Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
     const query = goship['goshipMeta'].aggregate([{$match:match}]);
-    resolve([query.cursor()])
+    let postprocess = helpers.meta_xform(res)
+    resolve([query.cursor(), postprocess])
   });
 }
 

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -183,7 +183,7 @@ exports.findGoship = function(res, id,startDate,endDate,polygon,multipolygon,cen
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_match.bind(null, goship['goship'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, goship['goship'], params, local_filter))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
     "chai-json-schema": "^1.5.1",
     "mocha": "^9.1.1",
     "supertest": "^6.1.6",
-    "geojson-validation": "^0.1.6"
+    "geojson-validation": "^0.1.6",
+    "JSONStream": "1.3.5"
   }
 }

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -8,9 +8,9 @@ const $RefParser = require("@apidevtools/json-schema-ref-parser");
 const helpers = require('/tests/tests/helpers')
 
 const c = 1
-const cellprice = 0.001
+const cellprice = 0.0001
 const metaDiscount = 100
-const maxbulk = 100000
+const maxbulk = 1000000
 const bucketSize = 100
 
 $RefParser.dereference(rawspec, (err, schema) => {
@@ -117,25 +117,25 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("cost functions", function () {
       it("cost of entire globe for a day with data for a standard API route", async function () {
-        expect(helpers.cost('https://argovis-api.colorado.edu/argo?startDate=2000-01-01T00:00:00Z&endDate=2000-01-02T00:00:00Z&data=doxy', c, cellprice, metaDiscount, maxbulk)).to.almost.equal(360000000/13000*1*cellprice);
+        expect(helpers.cost('/argo?startDate=2000-01-01T00:00:00Z&endDate=2000-01-02T00:00:00Z&data=doxy', c, cellprice, metaDiscount, maxbulk)).to.almost.equal(360000000/13000*1*cellprice);
       });
     }); 
 
     describe("cost functions", function () {
       it("cost of entire globe for a day with data for a standard API route", async function () {
-        expect(helpers.cost('https://argovis-api.colorado.edu/argo?startDate=2000-01-01T00:00:00Z&endDate=2000-01-02T00:00:00Z', c, cellprice, metaDiscount, maxbulk)).to.almost.equal(360000000/13000*1*cellprice/metaDiscount);
+        expect(helpers.cost('/argo?startDate=2000-01-01T00:00:00Z&endDate=2000-01-02T00:00:00Z', c, cellprice, metaDiscount, maxbulk)).to.almost.equal(360000000/13000*1*cellprice/metaDiscount);
       });
     }); 
 
     describe("cost functions", function () {
-      it("cost of 15 deg box near equator for 6 months with data for a standard API route should prohibit more than a few such requests in parallel", async function () {
-        expect(helpers.cost('https://argovis-api.colorado.edu/argo?startDate=2000-01-01T00:00:00Z&endDate=2000-07-01T00:00:00Z&polygon=[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]&data=temperature', c, cellprice, metaDiscount, maxbulk)*10).to.be.greaterThan(bucketSize);
+      it("cost of 15 deg box near equator for 2 years with data for a standard API route should prohibit more than a few such requests in parallel", async function () {
+        expect(helpers.cost('/argo?startDate=2000-01-01T00:00:00Z&endDate=2002-01-01T00:00:00Z&polygon=[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]&data=temperature', c, cellprice, metaDiscount, maxbulk)*10).to.be.greaterThan(bucketSize);
       });
     }); 
 
     describe("cost functions", function () {
-      it("cost of 15 deg box near equator for 10 years with data for a standard API route should be out of scope", async function () {
-        expect(helpers.cost('https://argovis-api.colorado.edu/argo?startDate=2000-01-01T00:00:00Z&endDate=2010-01-01T00:00:00Z&polygon=[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]&data=temperature', c, cellprice, metaDiscount, maxbulk).code).to.eql(413);
+      it("cost of 15 deg box near equator for 30 years with data for a standard API route should be out of scope", async function () {
+        expect(helpers.cost('/argo?startDate=2000-01-01T00:00:00Z&endDate=2030-01-01T00:00:00Z&polygon=[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]&data=temperature', c, cellprice, metaDiscount, maxbulk).code).to.eql(413);
       });
     }); 
 }

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -112,6 +112,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
         const response = await request.get("/goship/meta?id=972_m0").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/goship/meta'].get.responses['200'].content['application/json'].schema);
       });
+    }); 
+
+    describe("GET /goship/meta", function () {
+      it("goship metadata 404s correctly", async function () {
+        const response = await request.get("/goship/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+      });
     });    
 
     describe("GET /goship", function () {


### PR DESCRIPTION
Rather than loading the entire result of a query into memory while we wait for the user to download the result, this PR sets up an end-to-end stream from mongo to the express response, significantly reducing the memory footprint of large requests.