### PR TITLE
search by source

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -876,6 +876,20 @@ paths:
         schema:
           type: number
           example: 518
+      - name: source
+        in: query
+        description: Experimental program source(s) to search for; document must match
+          all sources to be returned. Accepts ~ negation to filter out documents.
+          See /profiles/vocabulary?parameter=source for list of options.
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "argo_bgc,~argo_core"
+          items:
+            type: string
       - name: compression
         in: query
         description: Data compression strategy to apply.
@@ -1028,6 +1042,7 @@ paths:
           enum:
           - woceline
           - cchdo_cruise
+          - source
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -33,8 +33,8 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
     });
 };
 
-module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
-  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
+module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
+  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -952,6 +952,22 @@ module.exports.data_pipeline = function(res, pipefittings){
   )
 }
 
+module.exports.source_filter = function(sourcelist){
+  // sourcelist: argument passed to `source` query string variable: comma separated string of sources, with ~negation
+  // returns an aggregation stage reflecting negatable source.source searches
 
+  let sourcematch = {}
+  let smatches = sourcelist.filter(e => e.charAt(0)!='~')
+  let snegations = sourcelist.filter(e => e.charAt(0)=='~').map(x => x.substring(1))
+  if(smatches.length > 0 && snegations.length > 0){
+    sourcematch['source.source'] = {'$all': smatches, '$nin': snegations}
+  } else if (smatches.length > 0){
+    sourcematch['source.source'] = {'$all': smatches}
+  } else if (snegations.length > 0){
+    sourcematch['source.source'] = {'$nin': snegations}
+  }
+
+  return {$match: sourcematch}
+}
 
 

--- a/nodejs-server/middleware/ratelimiter/tokenbucket.js
+++ b/nodejs-server/middleware/ratelimiter/tokenbucket.js
@@ -63,6 +63,7 @@ module.exports.tokenbucket = function (req, res, next) {
 		else if(tokensnow >= 0){
 			hsetAsync(userbucket.key, "ntokens", tokensnow-requestCost, "lastUpdate", t).then(next())
 		} else {
+			console.log('request rejected on token bucket:', req['url'], tokensnow)
 			throw({"code": 429, "message": "You have temporarily exceeded your API request limit. You will be able to issue another request in "+String(-1*tokensnow)+" seconds. Long term, requests like the one you just made can be made every "+String(requestCost)+" seconds."})
 		}
 	})

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -61,6 +61,10 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
     }
 
     // decide y/n whether to service this request
+    if(source && ![id,(startDate && endDate),polygon,multipolygon,(center && radius),platform].some(x=>x)){
+      reject({"code": 400, "message": "Please combine source queries with at least one of a time range, spatial extent, id or platform search."})
+      return
+    }
     let bailout = helpers.request_sanitation(params.polygon, null, params.center, params.radius, params.multipolygon) 
     if(bailout){
       reject(bailout)

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -174,12 +174,13 @@ exports.findArgometa = function(id,platform) {
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * woceline String WOCE line to search for. See /profiles/vocabulary?parameter=woceline for list of options. (optional)
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
+ * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,compression,data,presRange) {
+exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/spec.json
+++ b/spec.json
@@ -555,6 +555,9 @@
                   "$ref": "#/components/parameters/cchdo_cruise"
                },
                {
+                  "$ref": "#/components/parameters/profileSource"
+               },
+               {
                   "$ref": "#/components/parameters/compression"
                },
                {
@@ -662,7 +665,7 @@
                   "description": "GO-SHIP query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["woceline", "cchdo_cruise"]
+                     "enum": ["woceline", "cchdo_cruise", "source"]
                   }
                }
             ],

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -128,6 +128,20 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /goship/vocabulary", function () {
+      it("make sure goship identifies set of sources correctly", async function () {
+        const response = await request.get("/goship/vocabulary?parameter=source").set({'x-argokey': 'developer'});
+        expect(response.body).to.have.members(['cchdo_woce'])
+      });
+    }); 
+
+    describe("GET /goship", function () {
+      it("check that a source filter on goship works as expected", async function () {
+        const response = await request.get("/goship?source=cchdo_woce&startDate=1996-04-01T00:00:00Z&endDate=1996-05-01T00:00:00Z").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(5)
+      });
+    }); 
+
     // argo
 
     describe("GET /argo", function () {
@@ -245,7 +259,6 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
-
     describe("GET /argo", function () {
       it("argo data filtered by source negation", async function () {
         const response = await request.get("/argo?polygon=[[-34,1],[-34,3],[-36,3],[-36,1],[-34,1]]&startDate=2011-11-01T00:00:00Z&endDate=2011-12-01T00:00:00Z&source=argo_core,~argo_bgc").set({'x-argokey': 'developer'});
@@ -253,7 +266,19 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /argo/vocabulary", function () {
+      it("get list of argo profiles", async function () {
+        const response = await request.get("/argo/vocabulary?parameter=platform").set({'x-argokey': 'developer'});
+         expect(response.body).to.have.members(['4901283', '13857']) 
+      });
+    });
 
+    describe("GET /argo", function () {
+      it("filters on source correctly", async function () {
+        const response = await request.get("/argo?startDate=2011-10-01T00:00:00Z&endDate=2011-12-01T00:00:00Z&source=argo_bgc").set({'x-argokey': 'developer'});
+         expect(response.body.length).to.eql(3);
+      });
+    });
 
     // legacy profiles route
 


### PR DESCRIPTION
 - Can't allow standalone `source` search, otherwise people could just ask for all `argo_core` and get 2.5M hits
 - Reintroduce source search for CCHDO data with similar constraints and vocab support.