### PR TITLE
goship -> cchdo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - docker network create travis
-  - docker container run -d --network travis --name database argovis/testdb:0.20
+  - docker container run -d --network travis --name database argovis/testdb:0.21
   - docker container run -d --network travis --name redis redis:7.0.2
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -769,12 +769,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Grid
-  /goship:
+  /cchdo:
     get:
       tags:
       - profiles
-      summary: GO-SHIP search and filter.
-      operationId: findGoship
+      summary: CCHDO search and filter.
+      operationId: findCCHDO
       parameters:
       - name: id
         in: query
@@ -938,7 +938,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/goship'
+                  $ref: '#/components/schemas/cchdo'
                 x-content-type: application/json
         "400":
           description: Bad Request
@@ -959,12 +959,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Profiles
-  /goship/meta:
+  /cchdo/meta:
     get:
       tags:
       - profiles
       summary: GO-SHIP metadata search and filter.
-      operationId: findGoshipmeta
+      operationId: findCCHDOmeta
       parameters:
       - name: id
         in: query
@@ -1003,7 +1003,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/goshipMeta'
+                  $ref: '#/components/schemas/cchdoMeta'
                 x-content-type: application/json
         "400":
           description: Bad Request
@@ -1024,12 +1024,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Profiles
-  /goship/vocabulary:
+  /cchdo/vocabulary:
     get:
       tags:
       - profiles
       summary: List all possible values for certain CCHDO query string parameters
-      operationId: goshipVocab
+      operationId: cchdoVocab
       parameters:
       - name: parameter
         in: query
@@ -3544,7 +3544,7 @@ components:
         - flg_sst
         - flg_sst1
         - flg_sst2
-    goship:
+    cchdo:
       required:
       - _id
       - basin
@@ -3583,9 +3583,9 @@ components:
             - missing_location
             - missing_timestamp
         data_keys:
-          $ref: '#/components/schemas/goship_data_keys'
+          $ref: '#/components/schemas/cchdo_data_keys'
         units:
-          $ref: '#/components/schemas/goship_units'
+          $ref: '#/components/schemas/cchdo_units'
         station:
           type: string
         cast:
@@ -4324,7 +4324,7 @@ components:
           - 0.80082819046101150206595775671303272247314453125
           type: type
         timestamp: 2000-01-23T04:56:07.000+00:00
-    goshipMeta:
+    cchdoMeta:
       required:
       - _id
       - cchdo_cruise_id
@@ -4374,7 +4374,7 @@ components:
         instrument: instrument
         _id: _id
         date_updated_argovis: 2000-01-23T04:56:07.000+00:00
-    goship_units:
+    cchdo_units:
       anyOf:
       - type: array
         items:
@@ -4725,7 +4725,7 @@ components:
             type: string
           user_sample_number_btl:
             type: string
-    goship_data_keys:
+    cchdo_data_keys:
       type: array
       items:
         type: string

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -876,6 +876,20 @@ paths:
         schema:
           type: number
           example: 518
+      - name: source
+        in: query
+        description: Experimental program source(s) to search for; document must match
+          all sources to be returned. Accepts ~ negation to filter out documents.
+          See /profiles/vocabulary?parameter=source for list of options.
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "argo_bgc,~argo_core"
+          items:
+            type: string
       - name: compression
         in: query
         description: Data compression strategy to apply.
@@ -1028,6 +1042,7 @@ paths:
           enum:
           - woceline
           - cchdo_cruise
+          - source
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -13,6 +13,16 @@ module.exports.argoVocab = function argoVocab (req, res, next, parameter) {
     });
 };
 
+module.exports.cchdoVocab = function cchdoVocab (req, res, next, parameter) {
+  Profiles.cchdoVocab(parameter)
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};
+
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
   Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
     .then(function (response) {
@@ -33,8 +43,8 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
     });
 };
 
-module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
-  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
+module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
+  Profiles.findCCHDO(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })
@@ -43,18 +53,8 @@ module.exports.findGoship = function findGoship (req, res, next, id, startDate, 
     });
 };
 
-module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {
-  Profiles.findGoshipmeta(id, woceline, cchdo_cruise)
-    .then(function (response) {
-      utils.writeJson(res, response);
-    })
-    .catch(function (response) {
-      utils.writeJson(res, response);
-    });
-};
-
-module.exports.goshipVocab = function goshipVocab (req, res, next, parameter) {
-  Profiles.goshipVocab(parameter)
+module.exports.findCCHDOmeta = function findCCHDOmeta (req, res, next, id, woceline, cchdo_cruise) {
+  Profiles.findCCHDOmeta(id, woceline, cchdo_cruise)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -33,8 +33,8 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
     });
 };
 
-module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange) {
-  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, compression, data, presRange)
+module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
+  Profiles.findGoship(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -39,8 +39,8 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
     });
 };
 
-module.exports.findGoship = function findGoship (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
-  Profiles.findGoship(res, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
+module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
+  Profiles.findCCHDO(res, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
@@ -50,8 +50,8 @@ module.exports.findGoship = function findGoship (req, res, next, id, startDate, 
     });
 };
 
-module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woceline, cchdo_cruise) {
-  Profiles.findGoshipmeta(res, id, woceline, cchdo_cruise)
+module.exports.findCCHDOmeta = function findCCHDOmeta (req, res, next, id, woceline, cchdo_cruise) {
+  Profiles.findCCHDOmeta(res, id, woceline, cchdo_cruise)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
       utils.writeJson(res, response, response.code);
@@ -61,8 +61,8 @@ module.exports.findGoshipmeta = function findGoshipmeta (req, res, next, id, woc
     });
 };
 
-module.exports.goshipVocab = function goshipVocab (req, res, next, parameter) {
-  Profiles.goshipVocab(parameter)
+module.exports.cchdoVocab = function cchdoVocab (req, res, next, parameter) {
+  Profiles.cchdoVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);
     },

--- a/nodejs-server/models/cchdo.js
+++ b/nodejs-server/models/cchdo.js
@@ -26,7 +26,7 @@ var sourceinfo = Schema({
   date_updated: {type: Date, required: false},
 })
 
-const goshipSchema = Schema({
+const cchdoSchema = Schema({
   _id: {type: String, required: true},
   metadata: {type: String, required: true},
   geolocation: {type: geolocation, required: true},
@@ -41,7 +41,7 @@ const goshipSchema = Schema({
   cast: {type: Number, required: true}
 });
 
-const goshipMetaSchema = Schema({
+const cchdoMetaSchema = Schema({
   _id: {type: String, required: true},
   date_updated_argovis: {type: Date, required: true},
   data_type: {type: String, required: true},
@@ -55,5 +55,5 @@ const goshipMetaSchema = Schema({
 });
 
 module.exports = {}
-module.exports.goshipMeta = mongoose.model('goshipMeta', goshipMetaSchema, 'goshipMeta');
-module.exports.goship = mongoose.model('goship', goshipSchema, 'goship');
+module.exports.cchdoMeta = mongoose.model('cchdoMeta', cchdoMetaSchema, 'cchdoMeta');
+module.exports.cchdo = mongoose.model('cchdo', cchdoSchema, 'cchdo');

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -174,12 +174,13 @@ exports.findArgometa = function(id,platform) {
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * woceline String WOCE line to search for. See /profiles/vocabulary?parameter=woceline for list of options. (optional)
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
+ * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,compression,data,presRange) {
+exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -21,6 +21,25 @@ exports.argoVocab = function(parameter) {
 
 
 /**
+ * List all possible values for certain CCHDO query string parameters
+ *
+ * parameter String GO-SHIP query string parameter to summarize possible values of.
+ * returns List
+ **/
+exports.cchdoVocab = function(parameter) {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = [ "", "" ];
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+
+
+/**
  * Argo search and filter.
  *
  * id String Unique ID to search for. (optional)
@@ -163,7 +182,7 @@ exports.findArgometa = function(id,platform) {
 
 
 /**
- * GO-SHIP search and filter.
+ * CCHDO search and filter.
  *
  * id String Unique ID to search for. (optional)
  * startDate Date ISO 8601 UTC date-time formatted string indicating the beginning of the time period of interest. (optional)
@@ -180,7 +199,7 @@ exports.findArgometa = function(id,platform) {
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
+exports.findCCHDO = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {
@@ -253,7 +272,7 @@ exports.findGoship = function(id,startDate,endDate,polygon,multipolygon,center,r
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * returns List
  **/
-exports.findGoshipmeta = function(id,woceline,cchdo_cruise) {
+exports.findCCHDOmeta = function(id,woceline,cchdo_cruise) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {
@@ -279,25 +298,6 @@ exports.findGoshipmeta = function(id,woceline,cchdo_cruise) {
   "_id" : "_id",
   "date_updated_argovis" : "2000-01-23T04:56:07.000+00:00"
 } ];
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
-  });
-}
-
-
-/**
- * List all possible values for certain CCHDO query string parameters
- *
- * parameter String GO-SHIP query string parameter to summarize possible values of.
- * returns List
- **/
-exports.goshipVocab = function(parameter) {
-  return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = [ "", "" ];
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -1,6 +1,6 @@
 'use strict';
 const Profile = require('../models/profile');
-const goship = require('../models/goship');
+const cchdo = require('../models/cchdo');
 const argo = require('../models/argo');
 const helpers = require('../helpers/helpers')
 const geojsonArea = require('@mapbox/geojson-area');
@@ -157,7 +157,7 @@ exports.findArgometa = function(res, id,platform) {
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findGoship = function(res, id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
+exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
   return new Promise(function(resolve, reject) {
 
     // input sanitization
@@ -207,17 +207,17 @@ exports.findGoship = function(res, id,startDate,endDate,polygon,multipolygon,cen
         }
         Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
-        metafilter = goship['goshipMeta'].aggregate([{$match: match}]).exec()
+        metafilter = cchdo['cchdoMeta'].aggregate([{$match: match}]).exec()
         metacomplete = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, goship['goship'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, cchdo['cchdo'], params, local_filter))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {
           
-          let postprocess = helpers.post_xform(goship['goshipMeta'], pp_params, search_result, res)
+          let postprocess = helpers.post_xform(cchdo['cchdoMeta'], pp_params, search_result, res)
           
           resolve([search_result[1], postprocess])
           
@@ -233,7 +233,7 @@ exports.findGoship = function(res, id,startDate,endDate,polygon,multipolygon,cen
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * returns List
  **/
-exports.findGoshipmeta = function(res, id,woceline,cchdo_cruise) {
+exports.findCCHDOmeta = function(res, id,woceline,cchdo_cruise) {
   return new Promise(function(resolve, reject) {
     let match = {
         '_id': id,
@@ -242,7 +242,7 @@ exports.findGoshipmeta = function(res, id,woceline,cchdo_cruise) {
     }
     Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
-    const query = goship['goshipMeta'].aggregate([{$match:match}]);
+    const query = cchdo['cchdoMeta'].aggregate([{$match:match}]);
     let postprocess = helpers.meta_xform(res)
     resolve([query.cursor(), postprocess])
   });
@@ -254,7 +254,7 @@ exports.findGoshipmeta = function(res, id,woceline,cchdo_cruise) {
  * parameter String GO-SHIP query string parameter to summarize possible values of.
  * returns List
  **/
-exports.goshipVocab = function(parameter) {
+exports.cchdoVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
     let lookup = {
         'woceline': 'woce_lines', // <parameter value> : <corresponding key in metadata document>
@@ -264,9 +264,9 @@ exports.goshipVocab = function(parameter) {
 
     let model = null
     if(parameter=='source'){
-      model = goship['goship']
+      model = cchdo['cchdo']
     } else {
-      model = goship['goshipMeta']
+      model = cchdo['cchdoMeta']
     }
 
     model.find().distinct(lookup[parameter], function (err, vocab) {

--- a/spec.json
+++ b/spec.json
@@ -519,13 +519,13 @@
             }
          }
       },
-      "/goship": {
+      "/cchdo": {
          "get": {
             "tags": [
                "profiles"
             ],
-            "summary": "GO-SHIP search and filter.",
-            "operationId": "findGoship",
+            "summary": "CCHDO search and filter.",
+            "operationId": "findCCHDO",
             "parameters": [
                {
                   "$ref": "#/components/parameters/genericID"
@@ -588,7 +588,7 @@
                         "schema": {
                            "type": "array",
                            "items": {
-                              "$ref": "#/components/schemas/goship"
+                              "$ref": "#/components/schemas/cchdo"
                            }
                         }
                      }
@@ -606,13 +606,13 @@
             }
          }
       },
-      "/goship/meta": {
+      "/cchdo/meta": {
          "get": {
             "tags": [
                "profiles"
             ],
             "summary": "GO-SHIP metadata search and filter.",
-            "operationId": "findGoshipmeta",
+            "operationId": "findCCHDOmeta",
             "parameters": [
                {
                   "$ref": "#/components/parameters/genericID"
@@ -632,7 +632,7 @@
                         "schema": {
                            "type": "array",
                            "items": {
-                              "$ref": "#/components/schemas/goshipMeta"
+                              "$ref": "#/components/schemas/cchdoMeta"
                            }
                         }
                      }
@@ -650,13 +650,13 @@
             }
          }
       },
-      "/goship/vocabulary": {
+      "/cchdo/vocabulary": {
          "get": {
             "tags": [
                "profiles"
             ],
             "summary": "List all possible values for certain CCHDO query string parameters",
-            "operationId": "goshipVocab",
+            "operationId": "cchdoVocab",
             "parameters": [
                {
                   "in": "query",
@@ -2532,7 +2532,7 @@
                "enum": ["ve","vn","err_lon","err_lat","err_ve","err_vn","gap","sst","sst1","sst2","err_sst","err_sst1","err_sst2","flg_sst","flg_sst1","flg_sst2"]
             }
          },
-         "goship": {
+         "cchdo": {
             "type": "object",
             "required": ["_id","metadata","geolocation","basin","timestamp", "data_keys", "units", "source", "station", "cast"],
             "properties": {
@@ -2566,10 +2566,10 @@
                   }
                },
                "data_keys": {
-                  "$ref": "#/components/schemas/goship_data_keys"
+                  "$ref": "#/components/schemas/cchdo_data_keys"
                },
                "units": {
-                  "$ref": "#/components/schemas/goship_units"
+                  "$ref": "#/components/schemas/cchdo_units"
                },
                "station": {
                   "type": "string"
@@ -2767,7 +2767,7 @@
                }
             }
          },
-         "goshipMeta": {
+         "cchdoMeta": {
             "type": "object",
             "required": ["_id", "date_updated_argovis", "data_type", "expocode", "cchdo_cruise_id", "woce_lines"],
             "properties":{
@@ -2810,7 +2810,7 @@
                }
             }
          },
-         "goship_units": {
+         "cchdo_units": {
             "anyOf": [
                {
                   "type": "array",
@@ -2997,7 +2997,7 @@
                }
             ] 
          },
-         "goship_data_keys": {
+         "cchdo_data_keys": {
             "type": "array",
             "items": {
                "type": "string",

--- a/spec.json
+++ b/spec.json
@@ -555,6 +555,9 @@
                   "$ref": "#/components/parameters/cchdo_cruise"
                },
                {
+                  "$ref": "#/components/parameters/profileSource"
+               },
+               {
                   "$ref": "#/components/parameters/compression"
                },
                {
@@ -662,7 +665,7 @@
                   "description": "GO-SHIP query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["woceline", "cchdo_cruise"]
+                     "enum": ["woceline", "cchdo_cruise", "source"]
                   }
                }
             ],

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -11,95 +11,95 @@ $RefParser.dereference(rawspec, (err, schema) => {
   }
   else {
 
-    // goship
+    // cchdo
 
-    describe("GET /goship", function () {
-      it("searches for goship profiles, dont request data", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo", function () {
+      it("searches for cchdo profiles, dont request data", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo'].get.responses['200'].content['application/json'].schema);
       });
     });
 
-    describe("GET /goship", function () {
-      it("searches for goship profiles with data=metadata-only", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=metadata-only").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo", function () {
+      it("searches for cchdo profiles with data=metadata-only", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=metadata-only").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo'].get.responses['200'].content['application/json'].schema);
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship metadata-only should still have units and data_keys", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=metadata-only").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo metadata-only should still have units and data_keys", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=metadata-only").set({'x-argokey': 'developer'});
         expect(response.body[0]).to.contain.keys('data_keys', 'units')
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data filter should return goship-consistent data", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo", function () {
+      it("cchdo with data filter should return cchdo-consistent data", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo'].get.responses['200'].content['application/json'].schema);
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data filter should return correct data_keys", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo with data filter should return correct data_keys", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
         expect(response.body[0].data_keys).to.have.members(['salinity_btl','oxygen_btl','pressure'])
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data filter should return correct units", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo with data filter should return correct units", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal({'salinity_btl':"psu",'oxygen_btl':"micromole/kg",'pressure':"decibar"})
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl&compression=basic").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo with data filter should return correct units, as a list when compressed", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl&compression=basic").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["psu","micromole/kg","decibar"])
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data=all filter should return goship-consistent data", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo", function () {
+      it("cchdo with data=all filter should return cchdo-consistent data", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo'].get.responses['200'].content['application/json'].schema);
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data=all filter should return correct data_keys", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo with data=all filter should return correct data_keys", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
         expect(response.body[0].data_keys).to.have.members([ "temperature_btl_woceqc", "bottle_number_btl_woceqc", "bottle_number_btl", "temperature_btl", "oxygen_btl_woceqc", "pressure", "pressure_ctd_woceqc", "oxygen_btl", "temperature_ctd", "salinity_btl", "oxygen_ctd", "potential_temperature_c_btl", "sample_ctd", "sample_btl", "salinity_btl_woceqc", "bottle_salinity_btl_woceqc", "oxygen_ctd_woceqc", "ctd_pressure_raw_btl", "bottle_salinity_btl", "temperature_ctd_woceqc", "salinity_ctd_woceqc", "salinity_ctd" ])
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship with data=all filter should return correct units", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo with data=all filter should return correct units", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal({"temperature_btl_woceqc":  "null","bottle_number_btl_woceqc":  "null","bottle_number_btl":  "null","temperature_btl":  "Celsius","oxygen_btl_woceqc":  "null","pressure":  "decibar","pressure_ctd_woceqc":  "null","oxygen_btl":  "micromole/kg","temperature_ctd":  "null","salinity_btl":  "psu","oxygen_ctd":  "null","potential_temperature_c_btl":  "Celsius","sample_ctd":  "null","sample_btl":  "null","salinity_btl_woceqc":  "null","bottle_salinity_btl_woceqc":  "null","oxygen_ctd_woceqc":  "null","ctd_pressure_raw_btl":  "decibar","bottle_salinity_btl":  "psu","temperature_ctd_woceqc":  "null","salinity_ctd_woceqc":  "null","salinity_ctd" :  "null"})
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship levels should get dropped if they dont have requested data", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=salinity_btl").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo levels should get dropped if they dont have requested data", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=salinity_btl").set({'x-argokey': 'developer'});
         expect(response.body[0].data[0]['pressure']).to.eql(3.5)
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship profile should be dropped if no requested data is available", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=ctd_fluor_raw_btl").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo profile should be dropped if no requested data is available", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=ctd_fluor_raw_btl").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });
 
-    describe("GET /goship", function () {
-      it("goship levels should come out sorted by pressure", async function () {
-        const response = await request.get("/goship?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("cchdo levels should come out sorted by pressure", async function () {
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-57.8,-42],[-57.8,-43],[-57,-43],[-57,-42]]&data=all").set({'x-argokey': 'developer'});
         p = response.body[0].data.map(x => x.pressure)
         pp = JSON.parse(JSON.stringify(p))
         pp.sort((a,b)=>a-b)
@@ -107,37 +107,37 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
-    describe("GET /goship/meta", function () {
-      it("goship metadata", async function () {
-        const response = await request.get("/goship/meta?id=972_m0").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship/meta'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo/meta", function () {
+      it("cchdo metadata", async function () {
+        const response = await request.get("/cchdo/meta?id=972_m0").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo/meta'].get.responses['200'].content['application/json'].schema);
       });
     }); 
 
-    describe("GET /goship/meta", function () {
-      it("goship metadata 404s correctly", async function () {
-        const response = await request.get("/goship/meta?id=xxx").set({'x-argokey': 'developer'});
+    describe("GET /cchdo/meta", function () {
+      it("cchdo metadata 404s correctly", async function () {
+        const response = await request.get("/cchdo/meta?id=xxx").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });    
 
-    describe("GET /goship", function () {
-      it("goship data filtered by woceline", async function () {
-        const response = await request.get("/goship?woceline=AR08").set({'x-argokey': 'developer'});
-        expect(response.body).to.be.jsonSchema(schema.paths['/goship'].get.responses['200'].content['application/json'].schema);
+    describe("GET /cchdo", function () {
+      it("cchdo data filtered by woceline", async function () {
+        const response = await request.get("/cchdo?woceline=AR08").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/cchdo'].get.responses['200'].content['application/json'].schema);
       });
     }); 
 
-    describe("GET /goship/vocabulary", function () {
-      it("make sure goship identifies set of sources correctly", async function () {
-        const response = await request.get("/goship/vocabulary?parameter=source").set({'x-argokey': 'developer'});
+    describe("GET /cchdo/vocabulary", function () {
+      it("make sure cchdo identifies set of sources correctly", async function () {
+        const response = await request.get("/cchdo/vocabulary?parameter=source").set({'x-argokey': 'developer'});
         expect(response.body).to.have.members(['cchdo_woce'])
       });
     }); 
 
-    describe("GET /goship", function () {
-      it("check that a source filter on goship works as expected", async function () {
-        const response = await request.get("/goship?source=cchdo_woce&startDate=1996-04-01T00:00:00Z&endDate=1996-05-01T00:00:00Z").set({'x-argokey': 'developer'});
+    describe("GET /cchdo", function () {
+      it("check that a source filter on cchdo works as expected", async function () {
+        const response = await request.get("/cchdo?source=cchdo_woce&startDate=1996-04-01T00:00:00Z&endDate=1996-05-01T00:00:00Z").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(5)
       });
     }); 


### PR DESCRIPTION
The data from the CCHDO team is not, it turns out, confined to GO-SHIP data; it includes all kinds of other CCHDO products, too. Thus, the routes are better called `cchdo*` than `goship*`