### PR TITLE
compression=minimal

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -639,12 +639,9 @@ paths:
         explode: true
         schema:
           type: string
-<<<<<<< HEAD
           enum:
           - array
           - minimal
-=======
-          example: basic-minification
       - name: mostrecent
         in: query
         description: get back only the n records with the most recent values of timestamp.
@@ -653,7 +650,6 @@ paths:
         explode: true
         schema:
           type: number
->>>>>>> templates
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -922,12 +918,9 @@ paths:
         explode: true
         schema:
           type: string
-<<<<<<< HEAD
           enum:
           - array
           - minimal
-=======
-          example: basic-minification
       - name: mostrecent
         in: query
         description: get back only the n records with the most recent values of timestamp.
@@ -936,7 +929,6 @@ paths:
         explode: true
         schema:
           type: number
->>>>>>> templates
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -1228,12 +1220,9 @@ paths:
         explode: true
         schema:
           type: string
-<<<<<<< HEAD
           enum:
           - array
           - minimal
-=======
-          example: basic-minification
       - name: mostrecent
         in: query
         description: get back only the n records with the most recent values of timestamp.
@@ -1242,7 +1231,6 @@ paths:
         explode: true
         schema:
           type: number
->>>>>>> templates
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -2155,12 +2143,9 @@ paths:
         explode: true
         schema:
           type: string
-<<<<<<< HEAD
           enum:
           - array
           - minimal
-=======
-          example: basic-minification
       - name: mostrecent
         in: query
         description: get back only the n records with the most recent values of timestamp.
@@ -2169,7 +2154,6 @@ paths:
         explode: true
         schema:
           type: number
->>>>>>> templates
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -371,13 +371,15 @@ paths:
           example: LANE
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -623,13 +625,15 @@ paths:
           example: 50
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -892,13 +896,15 @@ paths:
             type: string
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -1184,13 +1190,15 @@ paths:
             type: string
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -1506,13 +1514,15 @@ paths:
           example: A10
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -2095,13 +2105,15 @@ paths:
           example: "4902911"
       - name: compression
         in: query
-        description: Data compression strategy to apply.
+        description: Data minification strategy to apply.
         required: false
         style: form
         explode: true
         schema:
           type: string
-          example: basic-minification
+          enum:
+          - array
+          - minimal
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -5288,13 +5300,15 @@ components:
     compression:
       name: compression
       in: query
-      description: Data compression strategy to apply.
+      description: Data minification strategy to apply.
       required: false
       style: form
       explode: true
       schema:
         type: string
-        example: basic-minification
+        enum:
+        - array
+        - minimal
     genericID:
       name: id
       in: query

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -566,7 +566,7 @@ module.exports.postprocess = function(pp_params, search_result){
     }
 
     /// deflate data if requested
-    if(pp_params.compression && pp_params.data && !metadata_only){
+    if(pp_params.compression=='array' && pp_params.data && !metadata_only){
       doc.data = doc.data.map(x => {
         let lvl = []
         for(let ii=0; ii<doc.data_keys.length; ii++){
@@ -714,7 +714,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params){
   }
 
   // deflate data if requested
-  if(pp_params.compression && pp_params.data && !metadata_only){
+  if(pp_params.compression == 'array' && pp_params.data && !metadata_only){
     chunk.data = chunk.data.map(x => {
       let lvl = []
       for(let ii=0; ii<chunk.data_keys.length; ii++){
@@ -727,6 +727,15 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params){
       return lvl
     })
     chunk.units = chunk.data_keys.map(x => chunk.units[x])
+  }
+
+  // return a minimal version if requested
+  if(pp_params.compression == 'minimal'){
+    chunk = {
+      '_id': chunk['_id'],
+      'geolocation': chunk['geolocation'],
+      'timestamp': chunk['timestamp']
+    }
   }
 
   return chunk

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -731,11 +731,8 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params){
 
   // return a minimal version if requested
   if(pp_params.compression == 'minimal'){
-    chunk = {
-      '_id': chunk['_id'],
-      'geolocation': chunk['geolocation'],
-      'timestamp': chunk['timestamp']
-    }
+    let sourceset = new Set(chunk.source.map(x => x.source).flat())
+    chunk = [chunk['_id'], chunk.geolocation.coordinates[0], chunk.geolocation.coordinates[1], chunk.timestamp, Array.from(sourceset) ]
   }
 
   return chunk

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -87,7 +87,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * wmo BigDecimal World Meteorological Organization identification number (optional)
  * platform String Unique platform ID to search for. (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -12,7 +12,7 @@
  * multipolygon String array of polygon regions; region of interest is taken as the intersection of all listed polygons. (optional)
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -51,7 +51,7 @@ exports.cchdoVocab = function(parameter) {
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * platform String Unique platform ID to search for. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data argo_data_keys Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
@@ -194,7 +194,7 @@ exports.findArgometa = function(id,platform) {
  * woceline String WOCE line to search for. See /profiles/vocabulary?parameter=woceline for list of options. (optional)
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
@@ -323,7 +323,7 @@ exports.findCCHDOmeta = function(id,woceline,cchdo_cruise) {
  * dac String Data Assembly Center to search for. See /profiles/vocabulary?parameter=dac for list of options. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * woceline String WOCE line to search for. See /profiles/vocabulary?parameter=woceline for list of options. (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. See /profiles/vocabulary?parameter=data for possible values. (optional)
  * returns List
  **/

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -12,7 +12,7 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * name String name of tropical cyclone (optional)
- * compression String Data compression strategy to apply. (optional)
+ * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/

--- a/spec.json
+++ b/spec.json
@@ -3319,10 +3319,10 @@
          "compression": {
             "in": "query",
             "name": "compression",
-            "description": "Data compression strategy to apply.",
+            "description": "Data minification strategy to apply.",
             "schema": {
                "type": "string",
-               "example": "basic-minification"
+               "enum": ["array","minimal"]
             }
          },
          "genericID": {

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -48,7 +48,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /drifters", function () {
       it("drifters with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/drifters?polygon=[[-17,14],[-18,14],[-18,15],[-17,15],[-17,14]]&data=sst,ve&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/drifters?polygon=[[-17,14],[-18,14],[-18,15],[-17,15],[-17,14]]&data=sst,ve&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["Kelvin","m/s"])
       });
     });
@@ -146,14 +146,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /drifters", function () {
       it("ignore compression without data", async function () {
-        const response = await request.get("/drifters?id=101143_0&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/drifters?id=101143_0&compression=array").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     }); 
 
     describe("GET /drifters", function () {
       it("ignore compression on metadata-only flag", async function () {
-        const response = await request.get("/drifters?id=101143_0&compression=basic&data=sst,metadata-only").set({'x-argokey': 'developer'});
+        const response = await request.get("/drifters?id=101143_0&compression=array&data=sst,metadata-only").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
     }); 

--- a/tests/tests/grid.tests.js
+++ b/tests/tests/grid.tests.js
@@ -48,7 +48,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /grids/ohc_kg", function () {
       it("grids with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/grids/ohc_kg?polygon=[[107,-64],[108,-64],[108,-65],[107,-65],[107,-64]]&data=ohc_kg&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/grids/ohc_kg?polygon=[[107,-64],[108,-64],[108,-65],[107,-65],[107,-64]]&data=ohc_kg&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["J/m^2"])
       });
     });
@@ -112,7 +112,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /grids/temperature_rg", function () {
       it("fetch gridded data with pressure bracket", async function () {
-        const response = await request.get("/grids/temperature_rg?id=20190115000000_20.5_-64.5&presRange=10,100&data=temperature_rg&compression=basic-minification").set({'x-argokey': 'developer'});
+        const response = await request.get("/grids/temperature_rg?id=20190115000000_20.5_-64.5&presRange=10,100&data=temperature_rg&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0]['data']).to.eql( [[ 0.37 ], [ 0.11 ], [ -0.318 ], [ -0.959 ], [ -1.37 ], [ -1.508 ], [ -1.468 ], [ -1.206 ], [ -0.745 ], [ -0.275 ]]);
       });
     });

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -57,7 +57,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /cchdo", function () {
       it("cchdo with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/cchdo?polygon=[[-57,-42],[-58,-42],[-58,-43],[-57,-43],[-57,-42]]&data=salinity_btl,oxygen_btl&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["psu","micromole/kg","decibar"])
       });
     });
@@ -195,7 +195,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /argo", function () {
       it("argo with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/argo?id=4901283_021&data=salinity,doxy&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?id=4901283_021&data=salinity,doxy&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["psu","micromole/kg","decibar"])
       });
     });
@@ -287,75 +287,75 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /argo", function () {
+      it("map compression reponds appropriately", async function () {
+        const response = await request.get("/argo?startDate=2011-10-01T00:00:00Z&endDate=2011-12-01T00:00:00Z&source=argo_bgc&compression=minimal").set({'x-argokey': 'developer'});
+         expect(response.body).to.eql([{"_id" : "4901283_023", "geolocation" : { "type" : "Point", "coordinates" : [ -34.50668290323591, 2.238459475658293 ] }, "timestamp": "2011-11-18T08:41:51.000Z"},{"_id" : "4901283_022", "geolocation" : { "type" : "Point", "coordinates" : [ -35.670215, 2.313375 ] }, "timestamp" : "2011-11-08T08:44:06.000Z"},{"_id" : "4901283_021", "geolocation" : { "type" : "Point", "coordinates" : [ -35.430227, 1.315393 ] }, "timestamp" : "2011-10-29T08:43:51.000Z"}]) 
+      });
+    });
+
     // legacy profiles route
 
     describe("GET /profiles", function () {
       it("searches for profiles by date", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00.000Z&endDate=2006-04-16T00:00:00.000Z&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00.000Z&endDate=2006-04-16T00:00:00.000Z&compression=array").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/profiles'].get.responses['200'].content['application/json'].schema);
       });
     });
 
     describe("GET /profiles", function () {
       it("searches for profiles by date and geo", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&compression=array").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/profiles'].get.responses['200'].content['application/json'].schema);
       });
     });
 
     describe("GET /profiles", function () {
       it("gets only pressure measurements", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=pres&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=pres&compression=array").set({'x-argokey': 'developer'});
   
         expect(response.body[0].data_keys).to.eql(['pres']);
       });
     });
 
-    // describe("GET /profiles", function () {
-    //   it("fails on too long a date range", async function () {
-    //     const response = await request.get("/profiles?startDate=2020-01-01T00:00:00.000Z&endDate=2020-04-01T00:00:00.000Z&compression=basic").set({'x-argokey': 'developer'});
-    //     expect(response.status).to.eql(400);
-    //   });
-    // });
-
     describe("GET /profiles", function () {
       it("gets profiles for one platform", async function () {
-        const response = await request.get("/profiles?platform=2900448&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?platform=2900448&compression=array").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/profiles'].get.responses['200'].content['application/json'].schema);
       });
     });
 
     describe("GET /profiles", function () {
       it("fails on too many platforms", async function () {
-        const response = await request.get("/profiles?platforms=4902911,9999&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?platforms=4902911,9999&compression=array").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(400);
       });
     });
 
     describe("GET /profiles", function () {
       it("fails with an unclosed polygon", async function () {
-        const response = await request.get("/profiles?startDate=2020-01-01T00:00:00.000Z&endDate=2020-03-30T00:00:00.000Z&polygon=[[-54.228515625,41.50857729743935],[-57.919921875,36.1733569352216],[-51.328125,36.10237644873644],[-54.228515625,41.50857729743936]]&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2020-01-01T00:00:00.000Z&endDate=2020-03-30T00:00:00.000Z&polygon=[[-54.228515625,41.50857729743935],[-57.919921875,36.1733569352216],[-51.328125,36.10237644873644],[-54.228515625,41.50857729743936]]&compression=array").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(400);
       });
     });
 
     describe("GET /profiles", function () {
       it("cuts off pressures greater than 100", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=pres&presRange=0,100&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=pres&presRange=0,100&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].data[response.body[0].data.length-1][0]).to.be.lessThan(100)
       });
     });
 
     describe("GET /profiles", function () {
       it("should find 2 profiles within a 20 km of this point", async function () {
-        const response = await request.get("/profiles?platform=2900448&center=134.25,36.16&radius=20&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?platform=2900448&center=134.25,36.16&radius=20&compression=array").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(2)
       });
     });
 
     describe("GET /profiles", function () {
       it("should only return KO profiles", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&dac=KO&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&dac=KO&compression=array").set({'x-argokey': 'developer'});
         dacs = response.body.map(p => p.data_center)
         s = new Set(dacs)
         expect(Array.from(s)).to.eql(['KO'])
@@ -364,14 +364,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /profiles", function () {
       it("fails to find any nitrate in BGC measurements", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=nitrate&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-01T00:00:00.000Z&endDate=2006-05-01T00:00:00.000Z&polygon=[[134.23095703125,38.05674222065296],[131.912841796875,34.7506398050501],[136.219482421875,34.56990638085636],[134.23095703125,38.05674222065296]]&data=nitrate&compression=array").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(404);
       });
     });   
 
     describe("GET /profiles", function () {
       it("finds a core temperature measurement on the given day", async function () {
-        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-04-16T00:00:00Z&data=temp&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/profiles?startDate=2006-04-15T00:00:00Z&endDate=2006-04-16T00:00:00Z&data=temp&compression=array").set({'x-argokey': 'developer'});
         expect(response.status).to.eql(200);
       });
     });

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -290,7 +290,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /argo", function () {
       it("minimal compression reponds appropriately", async function () {
         const response = await request.get("/argo?startDate=2011-10-01T00:00:00Z&endDate=2011-12-01T00:00:00Z&source=argo_bgc&compression=minimal").set({'x-argokey': 'developer'});
-         expect(response.body).to.eql([{"_id" : "4901283_023", "geolocation" : { "type" : "Point", "coordinates" : [ -34.50668290323591, 2.238459475658293 ] }, "timestamp": "2011-11-18T08:41:51.000Z"},{"_id" : "4901283_022", "geolocation" : { "type" : "Point", "coordinates" : [ -35.670215, 2.313375 ] }, "timestamp" : "2011-11-08T08:44:06.000Z"},{"_id" : "4901283_021", "geolocation" : { "type" : "Point", "coordinates" : [ -35.430227, 1.315393 ] }, "timestamp" : "2011-10-29T08:43:51.000Z"}]) 
+         expect(response.body).to.eql([["4901283_023", -34.50668290323591, 2.238459475658293, "2011-11-18T08:41:51.000Z", ['argo_bgc', 'argo_core']],["4901283_022",-35.670215, 2.313375, "2011-11-08T08:44:06.000Z",  ['argo_bgc', 'argo_core']],["4901283_021", -35.430227, 1.315393, "2011-10-29T08:43:51.000Z",  ['argo_bgc', 'argo_core']]]) 
       });
     });
     

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -48,7 +48,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /tc", function () {
       it("tc with data filter should return correct units, as a list when compressed", async function () {
-        const response = await request.get("/tc?polygon=[[-94,27.5],[-95,27.5],[-95,28.5],[-94,28.5],[-94,27.5]]&data=wind&compression=basic").set({'x-argokey': 'developer'});
+        const response = await request.get("/tc?polygon=[[-94,27.5],[-95,27.5],[-95,28.5],[-94,28.5],[-94,27.5]]&data=wind&compression=array").set({'x-argokey': 'developer'});
         expect(response.body[0].units).to.deep.equal(["kt"])
       });
     });


### PR DESCRIPTION
A `compression=minimal` flag on the standard data route, to get back only lat, long, timestamp and id. Will be useful on map mode, and replaces the old `/profiles/listID` route.