### PR TITLE
mostrecent option

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -369,6 +369,16 @@ paths:
         schema:
           type: string
           example: LANE
+      - name: mostrecent
+        in: query
+        description: set true to get back only the most recent record from your search.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - "true"
       - name: compression
         in: query
         description: Data compression strategy to apply.
@@ -630,6 +640,16 @@ paths:
         schema:
           type: string
           example: basic-minification
+      - name: mostrecent
+        in: query
+        description: set true to get back only the most recent record from your search.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - "true"
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -899,6 +919,16 @@ paths:
         schema:
           type: string
           example: basic-minification
+      - name: mostrecent
+        in: query
+        description: set true to get back only the most recent record from your search.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - "true"
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -1191,6 +1221,16 @@ paths:
         schema:
           type: string
           example: basic-minification
+      - name: mostrecent
+        in: query
+        description: set true to get back only the most recent record from your search.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - "true"
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -2102,6 +2142,16 @@ paths:
         schema:
           type: string
           example: basic-minification
+      - name: mostrecent
+        in: query
+        description: set true to get back only the most recent record from your search.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - "true"
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -5403,6 +5453,17 @@ components:
       schema:
         type: number
         example: 50
+    mostrecent:
+      name: mostrecent
+      in: query
+      description: set true to get back only the most recent record from your search.
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: string
+        enum:
+        - "true"
     data:
       name: data
       in: query

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -371,14 +371,12 @@ paths:
           example: LANE
       - name: mostrecent
         in: query
-        description: set true to get back only the most recent record from your search.
+        description: get back only the n records with the most recent values of timestamp.
         required: false
         style: form
         explode: true
         schema:
-          type: string
-          enum:
-          - "true"
+          type: number
       - name: compression
         in: query
         description: Data compression strategy to apply.
@@ -642,14 +640,12 @@ paths:
           example: basic-minification
       - name: mostrecent
         in: query
-        description: set true to get back only the most recent record from your search.
+        description: get back only the n records with the most recent values of timestamp.
         required: false
         style: form
         explode: true
         schema:
-          type: string
-          enum:
-          - "true"
+          type: number
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -921,14 +917,12 @@ paths:
           example: basic-minification
       - name: mostrecent
         in: query
-        description: set true to get back only the most recent record from your search.
+        description: get back only the n records with the most recent values of timestamp.
         required: false
         style: form
         explode: true
         schema:
-          type: string
-          enum:
-          - "true"
+          type: number
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -1223,14 +1217,12 @@ paths:
           example: basic-minification
       - name: mostrecent
         in: query
-        description: set true to get back only the most recent record from your search.
+        description: get back only the n records with the most recent values of timestamp.
         required: false
         style: form
         explode: true
         schema:
-          type: string
-          enum:
-          - "true"
+          type: number
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -2144,14 +2136,12 @@ paths:
           example: basic-minification
       - name: mostrecent
         in: query
-        description: set true to get back only the most recent record from your search.
+        description: get back only the n records with the most recent values of timestamp.
         required: false
         style: form
         explode: true
         schema:
-          type: string
-          enum:
-          - "true"
+          type: number
       - name: data
         in: query
         description: "Keys of data to include. Return only documents that have all\
@@ -5456,14 +5446,12 @@ components:
     mostrecent:
       name: mostrecent
       in: query
-      description: set true to get back only the most recent record from your search.
+      description: get back only the n records with the most recent values of timestamp.
       required: false
       style: form
       explode: true
       schema:
-        type: string
-        enum:
-        - "true"
+        type: number
     data:
       name: data
       in: query

--- a/nodejs-server/controllers/Drifters.js
+++ b/nodejs-server/controllers/Drifters.js
@@ -13,8 +13,8 @@ module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, p
     });
 };
 
-module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, data) {
-  Drifters.drifterSearch(id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, data)
+module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, mostrecent, data) {
+  Drifters.drifterSearch(id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, mostrecent, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Grid = require('../service/GridService');
 
-module.exports.findgrid = function findgrid (req, res, next, gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, data, presRange) {
-  Grid.findgrid(gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, data, presRange)
+module.exports.findgrid = function findgrid (req, res, next, gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, mostrecent, data, presRange) {
+  Grid.findgrid(gridName, id, startDate, endDate, polygon, multipolygon, center, radius, compression, mostrecent, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -23,8 +23,8 @@ module.exports.cchdoVocab = function cchdoVocab (req, res, next, parameter) {
     });
 };
 
-module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange) {
-  Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, data, presRange)
+module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, mostrecent, data, presRange) {
+  Profiles.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, mostrecent, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })
@@ -43,8 +43,8 @@ module.exports.findArgometa = function findArgometa (req, res, next, id, platfor
     });
 };
 
-module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange) {
-  Profiles.findCCHDO(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, data, presRange)
+module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange) {
+  Profiles.findCCHDO(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Tc.js
+++ b/nodejs-server/controllers/Tc.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Tc = require('../service/TcService');
 
-module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, name, compression, data) {
-  Tc.findTC(id, startDate, endDate, polygon, multipolygon, center, radius, name, compression, data)
+module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, name, mostrecent, compression, data) {
+  Tc.findTC(id, startDate, endDate, polygon, multipolygon, center, radius, name, mostrecent, compression, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -424,7 +424,6 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
         spacetimeMatch.push( {$match: {"geolocation": {$geoWithin: {$geometry: params.multipolygon[i]}}}} )
       }
     }
-    spacetimeMatch.push({$sort: {'timestamp':-1}})
   }
 
   /// construct filter for matching metadata docs if required
@@ -434,7 +433,7 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
   }
 
   // set up aggregation and return promise to evaluate:
-  let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch)
+  let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch).push({$sort: {'timestamp':-1}})
 
   return model.aggregate(aggPipeline).cursor()
 }
@@ -748,6 +747,9 @@ module.exports.post_xform = function(metaModel, pp_params, search_result, res){
              if(doc){
                 this.push(doc)
                 nDocs++
+                if(pp_params.mostRecent){
+                  this._flush()
+                }
             }
             next()
           })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -433,7 +433,8 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
   }
 
   // set up aggregation and return promise to evaluate:
-  let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch).push({$sort: {'timestamp':-1}})
+  let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch)
+  aggPipeline.push({$sort: {'timestamp':-1}})
 
   return model.aggregate(aggPipeline).cursor()
 }
@@ -747,8 +748,8 @@ module.exports.post_xform = function(metaModel, pp_params, search_result, res){
              if(doc){
                 this.push(doc)
                 nDocs++
-                if(pp_params.mostRecent){
-                  this._flush()
+                if(pp_params.mostrecent){
+                  this.emit('end')
                 }
             }
             next()

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -744,13 +744,16 @@ module.exports.post_xform = function(metaModel, pp_params, search_result, res){
             // keep track of new metadata docs so we don't look them up twice
             if(!search_result[0].find(x => x._id == chunk['metadata'])) search_result[0].push(meta)
             // munge the chunk and push it downstream if it isn't rejected.
-            let doc = module.exports.postprocess_stream(chunk, meta, pp_params)
-             if(doc){
+            let doc = null
+            if(!pp_params.mostrecent || nDocs < pp_params.mostrecent){
+                /// ie dont even bother with post if we've exceeded our mostrecent cap
+                doc = module.exports.postprocess_stream(chunk, meta, pp_params)
+            }
+            if(doc){
+              if(!pp_params.mostrecent || nDocs < pp_params.mostrecent){
                 this.push(doc)
-                nDocs++
-                if(pp_params.mostrecent){
-                  this.emit('end')
-                }
+              }
+              nDocs++
             }
             next()
           })

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -88,7 +88,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
  * wmo BigDecimal World Meteorological Organization identification number (optional)
  * platform String Unique platform ID to search for. (optional)
  * compression String Data compression strategy to apply. (optional)
- * mostrecent String set true to get back only the most recent record from your search. (optional)
+ * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -88,10 +88,11 @@ exports.drifterMetaSearch = function(platform,wmo) {
  * wmo BigDecimal World Meteorological Organization identification number (optional)
  * platform String Unique platform ID to search for. (optional)
  * compression String Data compression strategy to apply. (optional)
+ * mostrecent String set true to get back only the most recent record from your search. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/
-exports.drifterSearch = function(id,startDate,endDate,polygon,multipolygon,center,radius,wmo,platform,compression,data) {
+exports.drifterSearch = function(id,startDate,endDate,polygon,multipolygon,center,radius,wmo,platform,compression,mostrecent,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -13,11 +13,12 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * compression String Data compression strategy to apply. (optional)
+ * mostrecent String set true to get back only the most recent record from your search. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findgrid = function(gridName,id,startDate,endDate,polygon,multipolygon,center,radius,compression,data,presRange) {
+exports.findgrid = function(gridName,id,startDate,endDate,polygon,multipolygon,center,radius,compression,mostrecent,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -13,7 +13,7 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * compression String Data compression strategy to apply. (optional)
- * mostrecent String set true to get back only the most recent record from your search. (optional)
+ * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -52,7 +52,7 @@ exports.cchdoVocab = function(parameter) {
  * platform String Unique platform ID to search for. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
- * mostrecent String set true to get back only the most recent record from your search. (optional)
+ * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * data argo_data_keys Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
@@ -196,7 +196,7 @@ exports.findArgometa = function(id,platform) {
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
- * mostrecent String set true to get back only the most recent record from your search. (optional)
+ * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -86,7 +86,8 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
     let pp_params = {
         compression: compression,
         data: data,
-        presRange: presRange
+        presRange: presRange,
+        mostRecent: mostRecent
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -52,11 +52,12 @@ exports.cchdoVocab = function(parameter) {
  * platform String Unique platform ID to search for. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
+ * mostrecent String set true to get back only the most recent record from your search. (optional)
  * data argo_data_keys Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,radius,platform,source,compression,data,presRange) {
+exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,radius,platform,source,compression,mostrecent,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {
@@ -195,11 +196,12 @@ exports.findArgometa = function(id,platform) {
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /profiles/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /profiles/vocabulary?parameter=source for list of options. (optional)
  * compression String Data compression strategy to apply. (optional)
+ * mostrecent String set true to get back only the most recent record from your search. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findCCHDO = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,data,presRange) {
+exports.findCCHDO = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,mostrecent,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -12,7 +12,7 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * name String name of tropical cyclone (optional)
- * mostrecent String set true to get back only the most recent record from your search. (optional)
+ * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * compression String Data compression strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -12,11 +12,12 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * name String name of tropical cyclone (optional)
+ * mostrecent String set true to get back only the most recent record from your search. (optional)
  * compression String Data compression strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/
-exports.findTC = function(id,startDate,endDate,polygon,multipolygon,center,radius,name,compression,data) {
+exports.findTC = function(id,startDate,endDate,polygon,multipolygon,center,radius,name,mostrecent,compression,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/spec.json
+++ b/spec.json
@@ -231,6 +231,9 @@
                   "$ref": "#/components/parameters/tcName"
                },
                {
+                  "$ref": "#/components/parameters/mostrecent"
+               },
+               {
                   "$ref": "#/components/parameters/compression"
                },
                {
@@ -404,6 +407,9 @@
                   "$ref": "#/components/parameters/compression"
                },
                {
+                  "$ref": "#/components/parameters/mostrecent"
+               },
+               {
                   "name": "data",
                   "in": "query",
                   "description": "Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses.",
@@ -559,6 +565,9 @@
                },
                {
                   "$ref": "#/components/parameters/compression"
+               },
+               {
+                  "$ref": "#/components/parameters/mostrecent"
                },
                {
                   "name": "data",
@@ -732,6 +741,9 @@
                },
                {
                   "$ref": "#/components/parameters/compression"
+               },
+               {
+                  "$ref": "#/components/parameters/mostrecent"
                },
                {
                   "name": "data",
@@ -1259,6 +1271,9 @@
                },
                {
                   "$ref": "#/components/parameters/compression"
+               },
+               {
+                  "$ref": "#/components/parameters/mostrecent"
                },
                {
                   "name": "data",
@@ -3422,6 +3437,15 @@
             "schema": {
                "type": "number",
                "example": 50
+            }
+         },
+         "mostrecent": {
+            "in": "query",
+            "name": "mostrecent",
+            "description": "set true to get back only the most recent record from your search.",
+            "schema": {
+               "type": "string",
+               "enum": ["true"]
             }
          },
          "data": {

--- a/spec.json
+++ b/spec.json
@@ -3442,10 +3442,9 @@
          "mostrecent": {
             "in": "query",
             "name": "mostrecent",
-            "description": "set true to get back only the most recent record from your search.",
+            "description": "get back only the n records with the most recent values of timestamp.",
             "schema": {
-               "type": "string",
-               "enum": ["true"]
+               "type": "number"
             }
          },
          "data": {

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -289,15 +289,29 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /argo", function () {
       it("gets correct time for most recent result", async function () {
-        const response = await request.get("/argo?platform=4901283&mostrecent=true").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?platform=4901283&mostrecent=1").set({'x-argokey': 'developer'});
          expect(response.body[0].timestamp).to.eql('2011-11-18T08:41:51.000Z');
       });
     });
 
     describe("GET /argo", function () {
       it("only gets one result", async function () {
-        const response = await request.get("/argo?platform=4901283&mostrecent=true").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?platform=4901283&mostrecent=1").set({'x-argokey': 'developer'});
          expect(response.body.length).to.eql(1);
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("gets most recent 2 results", async function () {
+        const response = await request.get("/argo?platform=4901283&mostrecent=2").set({'x-argokey': 'developer'});
+         expect(response.body.length).to.eql(2);
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("confirm mostrecent and data queries work together nicely", async function () {
+        const response = await request.get("/argo?platform=4901283&data=temperature_sfile&mostrecent=2").set({'x-argokey': 'developer'});
+         expect(response.body.length).to.eql(2);
       });
     });
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -287,6 +287,20 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /argo", function () {
+      it("gets correct time for most recent result", async function () {
+        const response = await request.get("/argo?platform=4901283&mostrecent=true").set({'x-argokey': 'developer'});
+         expect(response.body[0].timestamp).to.eql('2011-11-18T08:41:51.000Z');
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("only gets one result", async function () {
+        const response = await request.get("/argo?platform=4901283&mostrecent=true").set({'x-argokey': 'developer'});
+         expect(response.body.length).to.eql(1);
+      });
+    });
+
     // legacy profiles route
 
     describe("GET /profiles", function () {


### PR DESCRIPTION
Provides a `mostrecent=n` query string parameter on all standard data routes that restricts the data returned to only the documents with the n most recent values of timestamp. Replaces the old `/platforms/mostRecent?platform=4901283`, now would be ie `/argo?platform=4901283&mostrecent=1`. Note any integer can be provided to get the most recent n, if desired.