### PR TITLE
Summary documents

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -1388,6 +1388,102 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Profiles
+  /argo/overview:
+    get:
+      tags:
+      - profiles
+      summary: Summarizes some collection-level statistics about Argo data.
+      operationId: argoOverview
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_1'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Profiles
+  /argo/dacs:
+    get:
+      tags:
+      - profiles
+      summary: Summarizes some datacenter-level statistics about Argo data.
+      operationId: argoDACs
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_2'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Profiles
+  /argo/bgc:
+    get:
+      tags:
+      - profiles
+      summary: Summarizes some float-level statistics for Argo BGC floats.
+      operationId: argoBGC
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/inline_response_200_3'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Profiles
   /profiles:
     get:
       tags:
@@ -5150,6 +5246,65 @@ components:
           type: integer
       example:
         sum: 0
+    inline_response_200_1:
+      type: object
+      properties:
+        _id:
+          type: string
+          enum:
+          - argo_overview
+        summary:
+          $ref: '#/components/schemas/inline_response_200_1_summary'
+      example:
+        summary:
+          datacenters:
+          - datacenters
+          - datacenters
+          nCore: 0.80082819046101150206595775671303272247314453125
+          nBGC: 6.02745618307040320615897144307382404804229736328125
+          nDeep: 1.46581298050294517310021547018550336360931396484375
+          mostrecent: 2010-01-01T00:00:00Z
+        _id: argo_overview
+    inline_response_200_2:
+      type: object
+      properties:
+        _id:
+          type: string
+          enum:
+          - argo_dacs
+        summary:
+          type: array
+          items:
+            $ref: '#/components/schemas/inline_response_200_2_summary'
+      example:
+        summary:
+        - _id: _id
+          "n": 0.80082819046101150206595775671303272247314453125
+          mostrecent: 2010-01-01T00:00:00Z
+        - _id: _id
+          "n": 0.80082819046101150206595775671303272247314453125
+          mostrecent: 2010-01-01T00:00:00Z
+        _id: argo_dacs
+    inline_response_200_3:
+      type: object
+      properties:
+        _id:
+          type: string
+          enum:
+          - argo_bgc
+        summary:
+          type: array
+          items:
+            $ref: '#/components/schemas/inline_response_200_2_summary'
+      example:
+        summary:
+        - _id: _id
+          "n": 0.80082819046101150206595775671303272247314453125
+          mostrecent: 2010-01-01T00:00:00Z
+        - _id: _id
+          "n": 0.80082819046101150206595775671303272247314453125
+          mostrecent: 2010-01-01T00:00:00Z
+        _id: argo_bgc
     platform:
       example: "4902911"
       anyOf:
@@ -5172,6 +5327,46 @@ components:
           type: type
         type: type
         properties: {}
+    inline_response_200_1_summary:
+      type: object
+      properties:
+        nCore:
+          type: number
+        nBGC:
+          type: number
+        nDeep:
+          type: number
+        mostrecent:
+          type: string
+          format: date-time
+          example: 2010-01-01T00:00:00Z
+        datacenters:
+          type: array
+          items:
+            type: string
+      example:
+        datacenters:
+        - datacenters
+        - datacenters
+        nCore: 0.80082819046101150206595775671303272247314453125
+        nBGC: 6.02745618307040320615897144307382404804229736328125
+        nDeep: 1.46581298050294517310021547018550336360931396484375
+        mostrecent: 2010-01-01T00:00:00Z
+    inline_response_200_2_summary:
+      type: object
+      properties:
+        _id:
+          type: string
+        "n":
+          type: number
+        mostrecent:
+          type: string
+          format: date-time
+          example: 2010-01-01T00:00:00Z
+      example:
+        _id: _id
+        "n": 0.80082819046101150206595775671303272247314453125
+        mostrecent: 2010-01-01T00:00:00Z
   responses:
     badRequest:
       description: Bad Request

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -504,6 +504,7 @@ paths:
           type: string
           enum:
           - name
+          - data_keys
       responses:
         "200":
           description: OK
@@ -1073,6 +1074,7 @@ paths:
           - woceline
           - cchdo_cruise
           - source
+          - data_keys
       responses:
         "200":
           description: OK
@@ -1359,6 +1361,7 @@ paths:
           enum:
           - platform
           - source
+          - data_keys
       responses:
         "200":
           description: OK
@@ -2368,6 +2371,7 @@ paths:
           enum:
           - wmo
           - platform
+          - data_keys
       responses:
         "200":
           description: OK

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -761,6 +761,18 @@ paths:
       - grid
       summary: List all grid names currently available
       operationId: gridVocab
+      parameters:
+      - name: parameter
+        in: query
+        description: Grid query string parameter to summarize possible values of.
+          Note grid names correspond exactly to grid data_keys.
+        required: true
+        style: form
+        explode: true
+        schema:
+          type: string
+          enum:
+          - data_keys
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -23,8 +23,8 @@ module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
     });
 };
 
-module.exports.gridVocab = function gridVocab (req, res, next) {
-  Grid.gridVocab()
+module.exports.gridVocab = function gridVocab (req, res, next, parameter) {
+  Grid.gridVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -8,6 +8,9 @@ module.exports.argoBGC = function argoBGC (req, res, next) {
   Profiles.argoBGC()
     .then(function (response) {
       utils.writeJson(res, response);
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);
@@ -18,6 +21,9 @@ module.exports.argoDACs = function argoDACs (req, res, next) {
   Profiles.argoDACs()
     .then(function (response) {
       utils.writeJson(res, response);
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);
@@ -28,6 +34,9 @@ module.exports.argoOverview = function argoOverview (req, res, next) {
   Profiles.argoOverview()
     .then(function (response) {
       utils.writeJson(res, response);
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Profiles.js
+++ b/nodejs-server/controllers/Profiles.js
@@ -3,6 +3,36 @@
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ProfilesService');
 
+module.exports.argoBGC = function argoBGC (req, res, next) {
+  Profiles.argoBGC()
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};
+
+module.exports.argoDACs = function argoDACs (req, res, next) {
+  Profiles.argoDACs()
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};
+
+module.exports.argoOverview = function argoOverview (req, res, next) {
+  Profiles.argoOverview()
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};
+
 module.exports.argoVocab = function argoVocab (req, res, next, parameter) {
   Profiles.argoVocab(parameter)
     .then(function (response) {

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -1,6 +1,7 @@
 'use strict';
 const Drifter = require('../models/drifter');
 const helpers = require('../helpers/helpers')
+const summaries = require('../models/summary');
 
 /**
  * Search, reduce and download drifter metadata.
@@ -111,6 +112,10 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
  **/
 exports.drifterVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
+    if(parameter == 'data_keys'){
+      const query = summaries.find({"_id":"drifter_data_keys"}).lean()
+      query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
+    }
 
     let lookup = {
         'wmo': 'wmo', // <parameter value> : <corresponding key in metadata document>

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -3,6 +3,7 @@ const Grid = require('../models/grid');
 const helpers = require('../helpers/helpers')
 const GJV = require('geojson-validation');
 const geojsonArea = require('@mapbox/geojson-area');
+const summaries = require('../models/summary');
 
 /**
  * Metadata for grids by ID
@@ -101,12 +102,9 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
  **/
 exports.gridVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
-    Grid['gridMeta'].find().distinct('data_keys', function (err, vocab) {
-      if (err){
-        reject({"code": 500, "message": "Server error"});
-        return;
-      }
-      resolve(vocab)
-    })
+    if(parameter == 'data_keys'){
+      const query = summaries.find({"_id":"grid_data_keys"}).lean()
+      query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
+    }
   });
 }

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -123,9 +123,10 @@ exports.findgridMeta = function(id) {
 /**
  * List all grid names currently available
  *
+ * parameter String Grid query string parameter to summarize possible values of. Note grid names correspond exactly to grid data_keys.
  * returns List
  **/
-exports.gridVocab = function() {
+exports.gridVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -62,6 +62,10 @@ exports.argoVocab = function(parameter) {
       resolve(['argo_core', 'argo_bgc', 'argo_deep'])
       return
     }
+    if(parameter == 'data_keys'){
+      const query = summaries.find({"_id":"argo_data_keys"})
+      query.exec(helpers.queryCallback.bind(null,x=>{x['data_keys']}, resolve, reject))
+    }
     argo['argoMeta'].find().distinct(lookup[parameter], function (err, vocab) {
       if (err){
         reject({"code": 500, "message": "Server error"});

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -53,19 +53,20 @@ exports.argoOverview = function() {
  **/
 exports.argoVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
-    let lookup = {
-        'platform': 'platform', // <parameter value> : <corresponding key in metadata document>
-        'source': 'source.source'
-    }
-
     if(parameter == 'source'){
       resolve(['argo_core', 'argo_bgc', 'argo_deep'])
       return
     }
     if(parameter == 'data_keys'){
-      const query = summaries.find({"_id":"argo_data_keys"})
-      query.exec(helpers.queryCallback.bind(null,x=>{x['data_keys']}, resolve, reject))
+      const query = summaries.find({"_id":"argo_data_keys"}).lean()
+      query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
     }
+
+    let lookup = {
+        'platform': 'platform', // <parameter value> : <corresponding key in metadata document>
+        'source': 'source.source'
+    }
+
     argo['argoMeta'].find().distinct(lookup[parameter], function (err, vocab) {
       if (err){
         reject({"code": 500, "message": "Server error"});
@@ -304,6 +305,12 @@ exports.findCCHDOmeta = function(res, id,woceline,cchdo_cruise) {
  **/
 exports.cchdoVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
+    if(parameter == 'data_keys'){
+      // data_keys is a summary lookup
+      const query = summaries.find({"_id":"cchdo_data_keys"}).lean()
+      query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
+    }
+
     let lookup = {
         'woceline': 'woce_lines', // <parameter value> : <corresponding key in metadata document>
         'cchdo_cruise': 'cchdo_cruise_id',

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -2,6 +2,91 @@
 
 
 /**
+ * Summarizes some float-level statistics for Argo BGC floats.
+ *
+ * returns inline_response_200_3
+ **/
+exports.argoBGC = function() {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = {
+  "summary" : [ {
+    "_id" : "_id",
+    "n" : 0.8008281904610115,
+    "mostrecent" : "2010-01-01T00:00:00Z"
+  }, {
+    "_id" : "_id",
+    "n" : 0.8008281904610115,
+    "mostrecent" : "2010-01-01T00:00:00Z"
+  } ],
+  "_id" : "argo_bgc"
+};
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+
+
+/**
+ * Summarizes some datacenter-level statistics about Argo data.
+ *
+ * returns inline_response_200_2
+ **/
+exports.argoDACs = function() {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = {
+  "summary" : [ {
+    "_id" : "_id",
+    "n" : 0.8008281904610115,
+    "mostrecent" : "2010-01-01T00:00:00Z"
+  }, {
+    "_id" : "_id",
+    "n" : 0.8008281904610115,
+    "mostrecent" : "2010-01-01T00:00:00Z"
+  } ],
+  "_id" : "argo_dacs"
+};
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+
+
+/**
+ * Summarizes some collection-level statistics about Argo data.
+ *
+ * returns inline_response_200_1
+ **/
+exports.argoOverview = function() {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = {
+  "summary" : {
+    "datacenters" : [ "datacenters", "datacenters" ],
+    "nCore" : 0.8008281904610115,
+    "nBGC" : 6.027456183070403,
+    "nDeep" : 1.4658129805029452,
+    "mostrecent" : "2010-01-01T00:00:00Z"
+  },
+  "_id" : "argo_overview"
+};
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+
+
+/**
  * List all possible values for certain Argo query string parameters
  *
  * parameter String Argo query string parameter to summarize possible values of.

--- a/nodejs-server/service/ProfilesService.js
+++ b/nodejs-server/service/ProfilesService.js
@@ -2,6 +2,7 @@
 const Profile = require('../models/profile');
 const cchdo = require('../models/cchdo');
 const argo = require('../models/argo');
+const summaries = require('../models/summary');
 const helpers = require('../helpers/helpers')
 const geojsonArea = require('@mapbox/geojson-area');
 
@@ -12,24 +13,8 @@ const geojsonArea = require('@mapbox/geojson-area');
  **/
 exports.argoBGC = function() {
   return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = {
-  "summary" : [ {
-    "_id" : "_id",
-    "n" : 0.8008281904610115,
-    "mostrecent" : "2010-01-01T00:00:00Z"
-  }, {
-    "_id" : "_id",
-    "n" : 0.8008281904610115,
-    "mostrecent" : "2010-01-01T00:00:00Z"
-  } ],
-  "_id" : "argo_bgc"
-};
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
+    const query = summaries.find({"_id":"argo_bgc"})
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
   });
 }
 
@@ -41,24 +26,8 @@ exports.argoBGC = function() {
  **/
 exports.argoDACs = function() {
   return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = {
-  "summary" : [ {
-    "_id" : "_id",
-    "n" : 0.8008281904610115,
-    "mostrecent" : "2010-01-01T00:00:00Z"
-  }, {
-    "_id" : "_id",
-    "n" : 0.8008281904610115,
-    "mostrecent" : "2010-01-01T00:00:00Z"
-  } ],
-  "_id" : "argo_dacs"
-};
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
+    const query = summaries.find({"_id":"argo_dacs"})
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
   });
 }
 
@@ -70,22 +39,8 @@ exports.argoDACs = function() {
  **/
 exports.argoOverview = function() {
   return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = {
-  "summary" : {
-    "datacenters" : [ "datacenters", "datacenters" ],
-    "nCore" : 0.8008281904610115,
-    "nBGC" : 6.027456183070403,
-    "nDeep" : 1.4658129805029452,
-    "mostrecent" : "2010-01-01T00:00:00Z"
-  },
-  "_id" : "argo_overview"
-};
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
+    const query = summaries.find({"_id":"argo_overview"})
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
   });
 }
 

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -2,6 +2,7 @@
 const tc = require('../models/tc');
 const moment = require('moment');
 const helpers = require('../helpers/helpers')
+const summaries = require('../models/summary');
 
 /**
  * Tropical cyclone search and filter.
@@ -104,6 +105,10 @@ exports.findTCmeta = function(res, id,name) {
  **/
 exports.tcVocab = function(parameter) {
   return new Promise(function(resolve, reject) {
+    if(parameter == 'data_keys'){
+      const query = summaries.find({"_id":"tc_data_keys"}).lean()
+      query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
+    }
 
     let lookup = {
         'name': 'name' // <parameter value> : <corresponding key in metadata document>

--- a/spec.json
+++ b/spec.json
@@ -499,6 +499,18 @@
             ],
             "summary": "List all grid names currently available",
             "operationId": "gridVocab",
+            "parameters": [
+               {
+                  "in": "query",
+                  "name": "parameter",
+                  "required": true,
+                  "description": "Grid query string parameter to summarize possible values of. Note grid names correspond exactly to grid data_keys.",
+                  "schema": {
+                     "type": "string",
+                     "enum": ["data_keys"]
+                  }
+               }
+            ],
             "responses": {
                "200": {
                   "description": "OK",

--- a/spec.json
+++ b/spec.json
@@ -335,7 +335,7 @@
                   "description": "TC query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["name"]
+                     "enum": ["name", "data_keys"]
                   }
                }
             ],
@@ -674,7 +674,7 @@
                   "description": "GO-SHIP query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["woceline", "cchdo_cruise", "source"]
+                     "enum": ["woceline", "cchdo_cruise", "source", "data_keys"]
                   }
                }
             ],
@@ -842,7 +842,7 @@
                   "description": "Argo query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["platform", "source"]
+                     "enum": ["platform", "source", "data_keys"]
                   }
                }
             ],
@@ -1545,7 +1545,7 @@
                   "description": "/drifters query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["wmo", "platform"]
+                     "enum": ["wmo", "platform", "data_keys"]
                   }
                }
             ],

--- a/spec.json
+++ b/spec.json
@@ -872,6 +872,177 @@
             }
          }
       },
+      "/argo/overview": {
+         "get": {
+            "tags": [
+               "profiles"
+            ],
+            "summary": "Summarizes some collection-level statistics about Argo data.",
+            "operationId": "argoOverview",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "object",
+                           "properties": {
+                              "_id": {
+                                 "type": "string",
+                                 "enum": ["argo_overview"]
+                              },
+                              "summary": {
+                                 "type": "object",
+                                 "properties": {
+                                    "nCore": {
+                                       "type": "number"
+                                    },
+                                    "nBGC": {
+                                       "type": "number"
+                                    },
+                                    "nDeep": {
+                                       "type": "number"
+                                    },
+                                    "mostrecent": {                       
+                                       "type": "string",
+                                       "format": "date-time",
+                                       "example": "2010-01-01T00:00:00Z"
+                                    },
+                                    "datacenters": {
+                                       "type": "array",
+                                       "items": {
+                                          "type": "string"
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
+      "/argo/dacs": {
+         "get": {
+            "tags": [
+               "profiles"
+            ],
+            "summary": "Summarizes some datacenter-level statistics about Argo data.",
+            "operationId": "argoDACs",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "object",
+                           "properties": {
+                              "_id": {
+                                 "type": "string",
+                                 "enum": ["argo_dacs"]
+                              },
+                              "summary": {
+                                 "type": "array",
+                                 "items": {
+                                    "type": "object",
+                                    "properties": {
+                                       "_id": {
+                                          "type": "string"
+                                       },
+                                       "n": {
+                                          "type": "number"
+                                       },
+                                       "mostrecent": {                       
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "example": "2010-01-01T00:00:00Z"
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
+      "/argo/bgc": {
+         "get": {
+            "tags": [
+               "profiles"
+            ],
+            "summary": "Summarizes some float-level statistics for Argo BGC floats.",
+            "operationId": "argoBGC",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "object",
+                           "properties": {
+                              "_id": {
+                                 "type": "string",
+                                 "enum": ["argo_bgc"]
+                              },
+                              "summary": {
+                                 "type": "array",
+                                 "items": {
+                                    "type": "object",
+                                    "properties": {
+                                       "_id": {
+                                          "type": "string"
+                                       },
+                                       "n": {
+                                          "type": "number"
+                                       },
+                                       "mostrecent": {                       
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "example": "2010-01-01T00:00:00Z"
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
       "/profiles": {
          "get": {
             "tags": [


### PR DESCRIPTION
 - Returns summary docs to `/argo/dacs`, `/argo/bgc` and `/argo/overview`
 - Inserts `data_keys` as a valid vocab parameter on all routes, per Megan's suggestion.