### PR TITLE
metadata filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - docker network create travis
-  - docker container run -d --network travis --name database argovis/testdb:0.21
+  - docker container run -d --network travis --name database argovis/testdb:0.22
   - docker container run -d --network travis --name redis redis:7.0.2
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -35,6 +35,8 @@ tags:
   description: atmospheric river shapes
 - name: covar (experimental)
   description: Argo float position forcast product
+- name: summary (experimental)
+  description: Summary statistics (mostly for internal use)
 paths:
   /ar:
     get:
@@ -367,6 +369,14 @@ paths:
         schema:
           type: string
           example: LANE
+      - name: metadata
+        in: query
+        description: metadata pointer
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       - name: mostrecent
         in: query
         description: get back only the n records with the most recent values of timestamp.
@@ -503,6 +513,7 @@ paths:
           enum:
           - name
           - data_keys
+          - metadata
       responses:
         "200":
           description: OK
@@ -887,6 +898,14 @@ paths:
         schema:
           type: number
           example: 50
+      - name: metadata
+        in: query
+        description: metadata pointer
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       - name: woceline
         in: query
         description: WOCE line to search for. See /cchdo/vocabulary?parameter=woceline
@@ -1085,6 +1104,7 @@ paths:
           - cchdo_cruise
           - source
           - data_keys
+          - metadata
       responses:
         "200":
           description: OK
@@ -1201,6 +1221,14 @@ paths:
         schema:
           type: number
           example: 50
+      - name: metadata
+        in: query
+        description: metadata pointer
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       - name: platform
         in: query
         description: Unique platform ID to search for.
@@ -1372,6 +1400,7 @@ paths:
           - platform
           - source
           - data_keys
+          - metadata
       responses:
         "200":
           description: OK
@@ -1584,6 +1613,14 @@ paths:
         schema:
           type: number
           example: 50
+      - name: metadata
+        in: query
+        description: metadata pointer
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       - name: wmo
         in: query
         description: World Meteorological Organization identification number
@@ -1740,6 +1777,7 @@ paths:
           - wmo
           - platform
           - data_keys
+          - metadata
       responses:
         "200":
           description: OK
@@ -1769,6 +1807,49 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Drifters
+  /summary:
+    get:
+      tags:
+      - summary (experimental)
+      summary: Fetch a document from the summary collection by ID.
+      operationId: fetchSummary
+      parameters:
+      - name: id
+        in: query
+        description: Unique ID to search for.
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
+          example: 4902911_0
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-content-type: application/json
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: SummaryExperimental
 components:
   schemas:
     arShapeSchema:
@@ -4445,3 +4526,12 @@ components:
       schema:
         type: number
         example: 1300915
+    metadata:
+      name: metadata
+      in: query
+      description: metadata pointer
+      required: false
+      style: form
+      explode: true
+      schema:
+        type: string

--- a/nodejs-server/controllers/Argo.js
+++ b/nodejs-server/controllers/Argo.js
@@ -43,8 +43,8 @@ module.exports.argoVocab = function argoVocab (req, res, next, parameter) {
     });
 };
 
-module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, mostrecent, data, presRange) {
-  Argo.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, platform, source, compression, mostrecent, data, presRange)
+module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, metadata, platform, source, compression, mostrecent, data, presRange) {
+  Argo.findArgo(id, startDate, endDate, polygon, multipolygon, center, radius, metadata, platform, source, compression, mostrecent, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Cchdo.js
+++ b/nodejs-server/controllers/Cchdo.js
@@ -13,8 +13,8 @@ module.exports.cchdoVocab = function cchdoVocab (req, res, next, parameter) {
     });
 };
 
-module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange) {
-  Cchdo.findCCHDO(id, startDate, endDate, polygon, multipolygon, center, radius, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange)
+module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, metadata, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange) {
+  Cchdo.findCCHDO(id, startDate, endDate, polygon, multipolygon, center, radius, metadata, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Drifters.js
+++ b/nodejs-server/controllers/Drifters.js
@@ -13,8 +13,8 @@ module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, p
     });
 };
 
-module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, mostrecent, data) {
-  Drifters.drifterSearch(id, startDate, endDate, polygon, multipolygon, center, radius, wmo, platform, compression, mostrecent, data)
+module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, metadata, wmo, platform, compression, mostrecent, data) {
+  Drifters.drifterSearch(id, startDate, endDate, polygon, multipolygon, center, radius, metadata, wmo, platform, compression, mostrecent, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/SummaryExperimental.js
+++ b/nodejs-server/controllers/SummaryExperimental.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var utils = require('../utils/writer.js');
+var SummaryExperimental = require('../service/SummaryExperimentalService');
+
+module.exports.fetchSummary = function fetchSummary (req, res, next, id) {
+  SummaryExperimental.fetchSummary(id)
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};

--- a/nodejs-server/controllers/SummaryExperimental.js
+++ b/nodejs-server/controllers/SummaryExperimental.js
@@ -1,4 +1,5 @@
 'use strict';
+var helpers = require('../helpers/helpers')
 
 var utils = require('../utils/writer.js');
 var SummaryExperimental = require('../service/SummaryExperimentalService');
@@ -7,6 +8,9 @@ module.exports.fetchSummary = function fetchSummary (req, res, next, id) {
   SummaryExperimental.fetchSummary(id)
     .then(function (response) {
       utils.writeJson(res, response);
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Tc.js
+++ b/nodejs-server/controllers/Tc.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Tc = require('../service/TcService');
 
-module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, name, mostrecent, compression, data) {
-  Tc.findTC(id, startDate, endDate, polygon, multipolygon, center, radius, name, mostrecent, compression, data)
+module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, center, radius, name, metadata, mostrecent, compression, data) {
+  Tc.findTC(id, startDate, endDate, polygon, multipolygon, center, radius, name, metadata, mostrecent, compression, data)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -491,7 +491,7 @@ module.exports.cost = function(url, c, cellprice, metaDiscount, maxbulk){
       }
 
       //// query parameters that specify a larger but still circumscribed number of records
-      else if(qString.get('woceline') || qString.get('cchdo_cruise') || qString.get('platform') ){
+      else if(qString.get('woceline') || qString.get('cchdo_cruise') || qString.get('platform') || qString.get('metadata') ){
         c = 10
       }
 

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -9,6 +9,7 @@ module.exports.queryCallback = function(postprocess, resolve, reject, err, data)
 	// standard callback for a database query that should return an array, passed in as <data>.
 	// <postprocess> == optional function to mutate <data> before return
 	// <resolve> and <reject> == resolve and reject functions from a promise 
+    console.log('xxxx', data)
     if (err){
         console.log(err)
         reject({"code": 500, "message": "Server error"});

--- a/nodejs-server/models/summary.js
+++ b/nodejs-server/models/summary.js
@@ -3,8 +3,7 @@ var Schema = mongoose.Schema;
 
 var summarySchema = Schema(
     {
-      _id: {type: String, required: true},
-      summary: {type: Schema.Types.Mixed, required: true}
+      _id: {type: String, required: true}
     }
   );
 

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -119,9 +119,17 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
     }
 
     // local filter: fields in data collection other than geolocation and timestamp 
-    let local_filter = []
+    let local_filter = {$match:{}}
     if(id){
-        local_filter = [{$match:{'_id':id}}]
+        local_filter['$match']['_id'] = id
+    }
+    if(metadata){
+      local_filter['$match']['metadata'] = metadata
+    }
+    if(Object.keys(local_filter['$match']).length > 0){
+      local_filter = [local_filter]
+    } else {
+      local_filter = []
     }
 
     // optional source filtering

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -115,6 +115,7 @@ exports.argoVocab = function(parameter) {
  * multipolygon String array of polygon regions; region of interest is taken as the intersection of all listed polygons. (optional)
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
+ * metadata String metadata pointer (optional)
  * platform String Unique platform ID to search for. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /<data route>/vocabulary?parameter=source for list of options. (optional)
  * compression String Data minification strategy to apply. (optional)
@@ -123,7 +124,7 @@ exports.argoVocab = function(parameter) {
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,radius,platform,source,compression,mostrecent,data,presRange) {
+exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,radius,metadata,platform,source,compression,mostrecent,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -62,10 +62,18 @@ exports.argoVocab = function(parameter) {
 
     let lookup = {
         'platform': 'platform', // <parameter value> : <corresponding key in metadata document>
-        'source': 'source.source'
+        'source': 'source.source',
+        'metadata': 'metadata'
     }
 
-    argo['argoMeta'].find().distinct(lookup[parameter], function (err, vocab) {
+    let model = null
+    if(parameter=='metadata'){
+      model = argo['argo']
+    } else {
+      model = argo['argoMeta']
+    }
+
+    model.find().distinct(lookup[parameter], function (err, vocab) {
       if (err){
         reject({"code": 500, "message": "Server error"});
         return;

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -142,11 +142,12 @@ exports.cchdoVocab = function(parameter) {
     let lookup = {
         'woceline': 'woce_lines', // <parameter value> : <corresponding key in metadata document>
         'cchdo_cruise': 'cchdo_cruise_id',
-        'source': 'source.source'
+        'source': 'source.source',
+        'metadata': 'metadata'
     }
 
     let model = null
-    if(parameter=='source'){
+    if(parameter=='source' || parameter=='metadata'){
       model = cchdo['cchdo']
     } else {
       model = cchdo['cchdoMeta']

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -30,6 +30,7 @@ exports.cchdoVocab = function(parameter) {
  * multipolygon String array of polygon regions; region of interest is taken as the intersection of all listed polygons. (optional)
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
+ * metadata String metadata pointer (optional)
  * woceline String WOCE line to search for. See /cchdo/vocabulary?parameter=woceline for list of options. (optional)
  * cchdo_cruise BigDecimal CCHDO cruise ID to search for. See /cchdo/vocabulary?parameter=cchdo_cruise for list of options. (optional)
  * source List Experimental program source(s) to search for; document must match all sources to be returned. Accepts ~ negation to filter out documents. See /<data route>/vocabulary?parameter=source for list of options. (optional)
@@ -39,7 +40,7 @@ exports.cchdoVocab = function(parameter) {
  * presRange List Pressure range in dbar to filter for; levels outside this range will not be returned. (optional)
  * returns List
  **/
-exports.findCCHDO = function(id,startDate,endDate,polygon,multipolygon,center,radius,woceline,cchdo_cruise,source,compression,mostrecent,data,presRange) {
+exports.findCCHDO = function(id,startDate,endDate,polygon,multipolygon,center,radius,metadata,woceline,cchdo_cruise,source,compression,mostrecent,data,presRange) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -48,9 +48,17 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
     }
 
     // local filter: fields in data collection other than geolocation and timestamp 
-    let local_filter = []
+    let local_filter = {$match:{}}
     if(id){
-        local_filter = [{$match:{'_id':id}}]
+        local_filter['$match']['_id'] = id
+    }
+    if(metadata){
+      local_filter['$match']['metadata'] = metadata
+    }
+    if(Object.keys(local_filter['$match']).length > 0){
+      local_filter = [local_filter]
+    } else {
+      local_filter = []
     }
 
     // optional source filtering

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -85,6 +85,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
  * multipolygon String array of polygon regions; region of interest is taken as the intersection of all listed polygons. (optional)
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
+ * metadata String metadata pointer (optional)
  * wmo BigDecimal World Meteorological Organization identification number (optional)
  * platform String Unique platform ID to search for. (optional)
  * compression String Data minification strategy to apply. (optional)
@@ -92,7 +93,7 @@ exports.drifterMetaSearch = function(platform,wmo) {
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/
-exports.drifterSearch = function(id,startDate,endDate,polygon,multipolygon,center,radius,wmo,platform,compression,mostrecent,data) {
+exports.drifterSearch = function(id,startDate,endDate,polygon,multipolygon,center,radius,metadata,wmo,platform,compression,mostrecent,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -63,9 +63,17 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
     }
 
     // local filter: fields in data collection other than geolocation and timestamp 
-    let local_filter = []
+    let local_filter = {$match:{}}
     if(id){
-        local_filter = [{$match:{'_id':id}}]
+        local_filter['$match']['_id'] = id
+    }
+    if(metadata){
+      local_filter['$match']['metadata'] = metadata
+    }
+    if(Object.keys(local_filter['$match']).length > 0){
+      local_filter = [local_filter]
+    } else {
+      local_filter = []
     }
 
     // postprocessing parameters

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -127,18 +127,30 @@ exports.drifterVocab = function(parameter) {
       query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
     }
 
-    let lookup = {
-        'wmo': 'wmo', // <parameter value> : <corresponding key in metadata document>
-        'platform': 'platform'
+    if(parameter == 'metadata'){
+      Drifter['drifter'].find().distinct('metadata', function (err, vocab) {
+        if (err){
+          reject({"code": 500, "message": "Server error"});
+          return;
+        }
+        resolve(vocab)
+      })
     }
 
-    Drifter['drifterMeta'].find().distinct(lookup[parameter], function (err, vocab) {
-      if (err){
-        reject({"code": 500, "message": "Server error"});
-        return;
+    if(parameter =='wmo' || parameter == 'platform'){
+      let lookup = {
+          'wmo': 'wmo', // <parameter value> : <corresponding key in metadata document>
+          'platform': 'platform'
       }
-      resolve(vocab)
-    })
+
+      Drifter['drifterMeta'].find().distinct(lookup[parameter], function (err, vocab) {
+        if (err){
+          reject({"code": 500, "message": "Server error"});
+          return;
+        }
+        resolve(vocab)
+      })
+    }
   });
 }
 

--- a/nodejs-server/service/SummaryExperimentalService.js
+++ b/nodejs-server/service/SummaryExperimentalService.js
@@ -1,0 +1,21 @@
+'use strict';
+
+
+/**
+ * Fetch a document from the summary collection by ID.
+ *
+ * id String Unique ID to search for. (optional)
+ * returns Object
+ **/
+exports.fetchSummary = function(id) {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = { };
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+

--- a/nodejs-server/service/SummaryExperimentalService.js
+++ b/nodejs-server/service/SummaryExperimentalService.js
@@ -1,5 +1,6 @@
 'use strict';
-
+const summaries = require('../models/summary');
+const helpers = require('../helpers/helpers')
 
 /**
  * Fetch a document from the summary collection by ID.
@@ -9,13 +10,7 @@
  **/
 exports.fetchSummary = function(id) {
   return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = { };
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
+    const query = summaries.find({"_id":id}).lean()
+    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
   });
 }
-

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -120,7 +120,7 @@ exports.tcVocab = function(parameter) {
       query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
     }
 
-    if(patameter == 'metadata'){
+    if(parameter == 'metadata'){
       tc['tc'].find().distinct('metadata', function (err, vocab) {
         if (err){
           reject({"code": 500, "message": "Server error"});

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -41,9 +41,17 @@ exports.findTC = function(res, id,startDate,endDate,polygon,multipolygon,center,
     }
 
     // local filter: fields in data collection other than geolocation and timestamp 
-    let local_filter = []
+    let local_filter = {$match:{}}
     if(id){
-        local_filter = [{$match:{'_id':id}}]
+        local_filter['$match']['_id'] = id
+    }
+    if(metadata){
+      local_filter['$match']['metadata'] = metadata
+    }
+    if(Object.keys(local_filter['$match']).length > 0){
+      local_filter = [local_filter]
+    } else {
+      local_filter = []
     }
 
     // postprocessing parameters

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -12,12 +12,13 @@
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
  * name String name of tropical cyclone (optional)
+ * metadata String metadata pointer (optional)
  * mostrecent BigDecimal get back only the n records with the most recent values of timestamp. (optional)
  * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * returns List
  **/
-exports.findTC = function(id,startDate,endDate,polygon,multipolygon,center,radius,name,mostrecent,compression,data) {
+exports.findTC = function(id,startDate,endDate,polygon,multipolygon,center,radius,name,metadata,mostrecent,compression,data) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -120,16 +120,24 @@ exports.tcVocab = function(parameter) {
       query.exec(helpers.queryCallback.bind(null,x=>x[0]['data_keys'], resolve, reject))
     }
 
-    let lookup = {
-        'name': 'name' // <parameter value> : <corresponding key in metadata document>
+    if(patameter == 'metadata'){
+      tc['tc'].find().distinct('metadata', function (err, vocab) {
+        if (err){
+          reject({"code": 500, "message": "Server error"});
+          return;
+        }
+        resolve(vocab)
+      })
     }
 
-    tc['tcMeta'].find().distinct(lookup[parameter], function (err, vocab) {
-      if (err){
-        reject({"code": 500, "message": "Server error"});
-        return;
-      }
-      resolve(vocab)
-    })
+    if(parameter == 'name'){
+      tc['tcMeta'].find().distinct('name', function (err, vocab) {
+        if (err){
+          reject({"code": 500, "message": "Server error"});
+          return;
+        }
+        resolve(vocab)
+      })
+    }
   });
 }

--- a/spec.json
+++ b/spec.json
@@ -57,6 +57,10 @@
       {
          "name": "covar (experimental)",
          "description": "Argo float position forcast product"
+      },
+      {
+         "name": "summary (experimental)",
+         "description": "Summary statistics (mostly for internal use)"
       }
    ],
    "paths": {
@@ -227,6 +231,9 @@
                   "$ref": "#/components/parameters/tcName"
                },
                {
+                  "$ref": "#/components/parameters/metadata"
+               },
+               {
                   "$ref": "#/components/parameters/mostrecent"
                },
                {
@@ -331,7 +338,7 @@
                   "description": "TC query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["name", "data_keys"]
+                     "enum": ["name", "data_keys", "metadata"]
                   }
                }
             ],
@@ -563,6 +570,9 @@
                   "$ref": "#/components/parameters/radius"
                },
                {
+                  "$ref": "#/components/parameters/metadata"
+               },
+               {
                   "$ref": "#/components/parameters/woceline"
                },
                {
@@ -682,7 +692,7 @@
                   "description": "GO-SHIP query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["woceline", "cchdo_cruise", "source", "data_keys"]
+                     "enum": ["woceline", "cchdo_cruise", "source", "data_keys", "metadata"]
                   }
                }
             ],
@@ -740,6 +750,9 @@
                },
                {
                   "$ref": "#/components/parameters/radius"
+               },
+               {
+                  "$ref": "#/components/parameters/metadata"
                },
                {
                   "$ref": "#/components/parameters/platformID"
@@ -850,7 +863,7 @@
                   "description": "Argo query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["platform", "source", "data_keys"]
+                     "enum": ["platform", "source", "data_keys", "metadata"]
                   }
                }
             ],
@@ -1081,6 +1094,9 @@
                   "$ref": "#/components/parameters/radius"
                },
                {
+                  "$ref": "#/components/parameters/metadata"
+               },
+               {
                   "$ref": "#/components/parameters/wmo"
                },
                {
@@ -1191,7 +1207,7 @@
                   "description": "/drifters query string parameter to summarize possible values of.",
                   "schema": {
                      "type": "string",
-                     "enum": ["wmo", "platform", "data_keys"]
+                     "enum": ["wmo", "platform", "data_keys", "metadata"]
                   }
                }
             ],
@@ -1205,6 +1221,41 @@
                            "items": {
                               "type": "string"
                            }
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
+      "/summary": {
+         "get": {
+            "tags": [
+               "summary (experimental)"
+            ],
+            "summary": "Fetch a document from the summary collection by ID.",
+            "operationId": "fetchSummary",   
+            "parameters": [
+               {
+                  "$ref": "#/components/parameters/genericID"
+               }
+            ],
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "object"
                         }
                      }
                   }
@@ -2704,6 +2755,14 @@
             "schema": {
                "type": "number",
                "example": 1300915
+            }
+         },
+         "metadata": {
+            "in": "query",
+            "name": "metadata",
+            "description": "metadata pointer",
+            "schema":{
+               "type": "string"
             }
          }
       },

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -102,6 +102,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });     
 
+    describe("GET /drifters/vocabulary", function () {
+      it("fetch possible drifter metadata keys", async function () {
+        const response = await request.get("/drifters/vocabulary?parameter=metadata").set({'x-argokey': 'developer'});
+        expect(response.body).to.have.members(['101143', '101528'])
+      });
+    }); 
+
     describe("GET /drifters", function () {
       it("fetch drifter data with a polygon filter", async function () {
         const response = await request.get("/drifters?polygon=[[-18,14],[-17,14],[-17,15],[-18,15],[-18,14]]").set({'x-argokey': 'developer'});

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -170,7 +170,17 @@ $RefParser.dereference(rawspec, (err, schema) => {
         const response = await request.get("/drifters/meta?platform=101143").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(1);
       });
+    }); 
+
+    describe("GET /drifters", function () {
+      it("metadata group lookup", async function () {
+        const response = await request.get("/drifters?metadata=101143").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(10);
+      });
     });     
   }
 })
+
+
+
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -142,6 +142,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /cchdo", function () {
+      it("check metadata group request", async function () {
+        const response = await request.get("/cchdo?metadata=972_m0").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(5)
+      });
+    }); 
+
+
     // argo
 
     describe("GET /argo", function () {
@@ -322,5 +330,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /argo", function () {
+      it("check metadata batch request", async function () {
+        const response = await request.get("/argo?metadata=4901283_m1").set({'x-argokey': 'developer'});
+         expect(response.body.length).to.eql(2);
+      });
+    });
+
   }
 })
+

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -135,6 +135,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /cchdo/vocabulary", function () {
+      it("make sure cchdo identifies metadata groups correctly", async function () {
+        const response = await request.get("/cchdo/vocabulary?parameter=metadata").set({'x-argokey': 'developer'});
+        expect(response.body).to.have.members(['972_m0'])
+      });
+    }); 
+
     describe("GET /cchdo", function () {
       it("check that a source filter on cchdo works as expected", async function () {
         const response = await request.get("/cchdo?source=cchdo_woce&startDate=1996-04-01T00:00:00Z&endDate=1996-05-01T00:00:00Z").set({'x-argokey': 'developer'});
@@ -282,9 +289,16 @@ $RefParser.dereference(rawspec, (err, schema) => {
     }); 
 
     describe("GET /argo/vocabulary", function () {
-      it("get list of argo profiles", async function () {
+      it("get list of argo platforms", async function () {
         const response = await request.get("/argo/vocabulary?parameter=platform").set({'x-argokey': 'developer'});
          expect(response.body).to.have.members(['4901283', '13857']) 
+      });
+    });
+
+    describe("GET /argo/vocabulary", function () {
+      it("get list of argo metadata groups", async function () {
+        const response = await request.get("/argo/vocabulary?parameter=metadata").set({'x-argokey': 'developer'});
+         expect(response.body).to.have.members(["4901283_m1", "4901283_m0", "13857_m0"]) 
       });
     });
 

--- a/tests/tests/summary.tests.js
+++ b/tests/tests/summary.tests.js
@@ -1,0 +1,25 @@
+const request = require("supertest")("http://api:8080");
+const expect = require("chai").expect;
+const chai = require('chai');
+chai.use(require('chai-json-schema'));
+const rawspec = require('/tests/spec.json');
+const $RefParser = require("@apidevtools/json-schema-ref-parser");
+
+$RefParser.dereference(rawspec, (err, schema) => {
+  if (err) {
+    console.error(err);
+  }
+  else {
+
+    describe("GET /summary", function () {
+      it("check a basic summary fetch", async function () {
+        const response = await request.get("/summary?id=example").set({'x-argokey': 'developer'});
+        expect(response.body[0]).to.deep.equal({"_id": "example", "summary": {"demo":[1,2,3,4]}})
+      });
+    });
+  }
+})
+
+
+
+

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -123,6 +123,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /tc/vocabulary", function () {
+      it("check tc data_keys vocab", async function () {
+        const response = await request.get("/tc/vocabulary?parameter=data_keys").set({'x-argokey': 'developer'});
+        expect(response.body).to.have.members(["surface_pressure", "wind"]) 
+      });
+    });
+
     describe("GET /tc?metadata", function () {
       it("should be 5 data records corresponding to this metadata key", async function () {
         const response = await request.get("/tc?metadata=AL011851").set({'x-argokey': 'developer'});

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -115,6 +115,17 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body).to.have.members(['DEMO', 'UNNAMED']) 
       });
     });
+
+    describe("GET /tc?metadata", function () {
+      it("should be 5 data records corresponding to this metadata key", async function () {
+        const response = await request.get("/tc?metadata=AL011851").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(5);  
+      });
+    }); 
+
   }
 })
+
+
+
 

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -110,9 +110,16 @@ $RefParser.dereference(rawspec, (err, schema) => {
     }); 
 
     describe("GET /tc/vocabulary", function () {
-      it("check tc vocab", async function () {
+      it("check tc name vocab", async function () {
         const response = await request.get("/tc/vocabulary?parameter=name").set({'x-argokey': 'developer'});
         expect(response.body).to.have.members(['DEMO', 'UNNAMED']) 
+      });
+    });
+
+    describe("GET /tc/vocabulary", function () {
+      it("check tc metadata vocab", async function () {
+        const response = await request.get("/tc/vocabulary?parameter=metadata").set({'x-argokey': 'developer'});
+        expect(response.body).to.have.members(['AL011851', 'AL041851']) 
       });
     });
 


### PR DESCRIPTION
 - On the data routes, add a `metadata` filter that returns all data docs matching the specified metadata id. Implemented for all standard routes except grids, as there are cases for the grids where this would return an enormous amount of records.
 - add `metadata` to corresponding vocab routes.