### PR TITLE
make it easier to extract time needed for api congestion to resolve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - docker network create travis
-  - docker container run -d --network travis --name database argovis/testdb:0.22
+  - docker container run -d --network travis --name database argovis/testdb:0.23
   - docker container run -d --network travis --name redis redis:7.0.2
   - docker image build -t argovis/api:test .
   - docker image build -f Dockerfile-test -t testrunner:dev .

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -9,7 +9,6 @@ module.exports.queryCallback = function(postprocess, resolve, reject, err, data)
 	// standard callback for a database query that should return an array, passed in as <data>.
 	// <postprocess> == optional function to mutate <data> before return
 	// <resolve> and <reject> == resolve and reject functions from a promise 
-    console.log('xxxx', data)
     if (err){
         console.log(err)
         reject({"code": 500, "message": "Server error"});

--- a/nodejs-server/middleware/ratelimiter/tokenbucket.js
+++ b/nodejs-server/middleware/ratelimiter/tokenbucket.js
@@ -65,7 +65,7 @@ module.exports.tokenbucket = function (req, res, next) {
 			hsetAsync(userbucket.key, "ntokens", tokensnow-requestCost, "lastUpdate", t).then(next())
 		} else {
 			console.log('request rejected on token bucket:', req['url'], tokensnow)
-			throw({"code": 429, "message": "You have temporarily exceeded your API request limit. You will be able to issue another request in "+String(-1*tokensnow)+" seconds. Long term, requests like the one you just made can be made every "+String(requestCost)+" seconds."})
+			throw({"code": 429, delay: [-1*tokensnow, requestCost], "message": "You have temporarily exceeded your API request limit. You will be able to issue another request in "+String(-1*tokensnow)+" seconds. Long term, requests like the one you just made can be made every "+String(requestCost)+" seconds."})
 		}
 	})
 	.catch(err => {


### PR DESCRIPTION
When the api throws a 429, provide the amount of time the user is blocked for, and the amount of time they should wait between issuing such requests.