### PR TITLE
drop profiles with no levels in presRange

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -296,6 +296,9 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params){
   // if we wanted data and none is left, abandon this document
   if(keys.length>(coerced_pressure ? 1 : 0) && chunk.data.length==0) return false
 
+  // if we asked for a pressure range and no levels are in that pressure range, abandon this document
+  if(pp_params.presRange && levels.length==0) return false
+
   // if we asked for specific data and one of the desired variables isn't found anywhere, abandon this document
   if(pp_params.data && (pp_params.data.length > 1 || pp_params.data[0]!=='except-data-values')){
     for(k=0; k<keys.length; k++){

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -351,6 +351,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /argo", function () {
+      it("shouldnt return a profile with no levels in presRange, even if not returning actual data levels", async function () {
+        const response = await request.get("/argo?presRange=2000,10000").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+      });
+    });
+
   }
 })
 


### PR DESCRIPTION
even when not returning actual data levels. Important for frontend applications that want to request `compression=minimal` but still filter on depth.