### PR TITLE
allow different datasets to present differently via compression=minimal

### DIFF
--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -171,7 +171,23 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
     Promise.all([metafilter, datafilter])
         .then(search_result => {
 
-          let postprocess = helpers.post_xform(argo['argoMeta'], pp_params, search_result, res)
+          let stub = function(data, metadata){
+              // given a data and corresponding metadata document,
+              // return the record that should be returned when the compression=minimal API flag is set
+              // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              
+              let sourceset = new Set(data.source.map(x => x.source).flat())
+
+              return [
+                data['_id'], 
+                data.geolocation.coordinates[0], 
+                data.geolocation.coordinates[1], 
+                data.timestamp,
+                Array.from(sourceset)
+              ]
+          }
+
+          let postprocess = helpers.post_xform(argo['argoMeta'], pp_params, search_result, res, stub)
 
           resolve([search_result[1], postprocess])
 

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -94,7 +94,21 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
     Promise.all([metafilter, datafilter])
         .then(search_result => {
           
-          let postprocess = helpers.post_xform(cchdo['cchdoMeta'], pp_params, search_result, res)
+          let stub = function(data, metadata){
+              // given a data and corresponding metadata document,
+              // return the record that should be returned when the compression=minimal API flag is set
+              // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              return [
+                data['_id'], 
+                data.geolocation.coordinates[0], 
+                data.geolocation.coordinates[1], 
+                data.timestamp,
+                metadata.woce_lines,
+                metadata.cchdo_cruise_id
+              ]
+          }
+
+          let postprocess = helpers.post_xform(cchdo['cchdoMeta'], pp_params, search_result, res, stub)
           
           resolve([search_result[1], postprocess])
           

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -98,11 +98,15 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
               // given a data and corresponding metadata document,
               // return the record that should be returned when the compression=minimal API flag is set
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              
+              let sourceset = new Set(data.source.map(x => x.source).flat())
+
               return [
                 data['_id'], 
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
                 data.timestamp,
+                Array.from(sourceset),
                 metadata.woce_lines,
                 metadata.cchdo_cruise_id
               ]

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -104,7 +104,20 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
     Promise.all([metafilter, datafilter])
         .then(search_result => {
 
-          let postprocess = helpers.post_xform(Drifter['drifterMeta'], pp_params, search_result, res)
+          let stub = function(data, metadata){
+              // given a data and corresponding metadata document,
+              // return the record that should be returned when the compression=minimal API flag is set
+              // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              return [
+                data['_id'], 
+                data.geolocation.coordinates[0], 
+                data.geolocation.coordinates[1], 
+                data.timestamp,
+                metadata.wmo
+              ]
+          }
+
+          let postprocess = helpers.post_xform(Drifter['drifterMeta'], pp_params, search_result, res, stub)
 
           resolve([search_result[1], postprocess])
 

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -85,7 +85,19 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
     Promise.all([metafilter, datafilter])
         .then(search_result => {
 
-          let postprocess = helpers.post_xform(Grid['gridMeta'], pp_params, search_result, res)
+          let stub = function(data, metadata){
+              // given a data and corresponding metadata document,
+              // return the record that should be returned when the compression=minimal API flag is set
+              // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              return [
+                data['_id'], 
+                data.geolocation.coordinates[0], 
+                data.geolocation.coordinates[1], 
+                data.timestamp
+              ]
+          }
+
+          let postprocess = helpers.post_xform(Grid['gridMeta'], pp_params, search_result, res, stub)
 
           resolve([search_result[1], postprocess])
 

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -76,7 +76,19 @@ exports.findTC = function(res, id,startDate,endDate,polygon,multipolygon,center,
     Promise.all([metafilter, datafilter])
         .then(search_result => {
 
-          let postprocess = helpers.post_xform(tc['tcMeta'], pp_params, search_result, res)
+          let stub = function(data, metadata){
+              // given a data and corresponding metadata document,
+              // return the record that should be returned when the compression=minimal API flag is set
+              // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
+              return [
+                data['_id'], 
+                data.geolocation.coordinates[0], 
+                data.geolocation.coordinates[1], 
+                data.timestamp
+              ]
+          }
+
+          let postprocess = helpers.post_xform(tc['tcMeta'], pp_params, search_result, res, stub)
 
           resolve([search_result[1], postprocess])
 

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -166,9 +166,9 @@ $RefParser.dereference(rawspec, (err, schema) => {
     }); 
 
     describe("GET /drifters", function () {
-      it("minimal compression on drifters", async function () {
-        const response = await request.get("/drifters?compression=minimal&startDate=2012-03-15T00:00:00Z&endDate=2012-03-16T00:00:00Z").set({'x-argokey': 'developer'});
-        expect(response.body.length).to.eql(2);
+      it("should return appropriate minimal representation of this measurement", async function () {
+        const response = await request.get("/drifters?id=101143_0&compression=minimal").set({'x-argokey': 'developer'});
+        expect(response.body).to.eql([['101143_0', -17.74345, 14.74677, "2012-03-15T22:00:00.000Z",1300915]]);  
       });
     }); 
 

--- a/tests/tests/grid.tests.js
+++ b/tests/tests/grid.tests.js
@@ -130,6 +130,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body.length).to.eql(2);
       });
     });
+
+    describe("GET /grids/ohc_kg", function () {
+      it("should return appropriate minimal representation of this measurement", async function () {
+        const response = await request.get("/grids/ohc_kg?id=20050115000000_107.5_-64.5&compression=minimal").set({'x-argokey': 'developer'});
+        expect(response.body).to.eql([['20050115000000_107.5_-64.5', 107.5, -64.5, "2005-01-15T00:00:00.000Z"]]);  
+      });
+    }); 
   }
 })
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -159,7 +159,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /cchdo", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/cchdo?id=expo_08PD0196_1_sta_016_cast_001&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['expo_08PD0196_1_sta_016_cast_001', -57.6833, -42.8133, "1996-04-01T10:24:00.000Z", [ "AR08" ], 972]]);  
+        expect(response.body).to.eql([['expo_08PD0196_1_sta_016_cast_001', -57.6833, -42.8133, "1996-04-01T10:24:00.000Z", [ "cchdo_woce" ], [ "AR08" ], 972]]);  
       });
     }); 
 

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -156,6 +156,12 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /cchdo", function () {
+      it("should return appropriate minimal representation of this measurement", async function () {
+        const response = await request.get("/cchdo?id=expo_08PD0196_1_sta_016_cast_001&compression=minimal").set({'x-argokey': 'developer'});
+        expect(response.body).to.eql([['expo_08PD0196_1_sta_016_cast_001', -57.6833, -42.8133, "1996-04-01T10:24:00.000Z", [ "AR08" ], 972]]);  
+      });
+    }); 
 
     // argo
 

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -137,6 +137,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /tc", function () {
+      it("should return appropriate minimal representation of this measurement", async function () {
+        const response = await request.get("/tc?id=AL011851_18510625000000&compression=minimal").set({'x-argokey': 'developer'});
+        expect(response.body).to.eql([['AL011851_18510625000000', -94.8, 28, "1851-06-25T00:00:00.000Z"]]);  
+      });
+    }); 
+
   }
 })
 


### PR DESCRIPTION
Root problem was that it was inconvenient to quickly associate a record returned using `compression=minimal` with a logical grouping, like WOCE occupancy or cyclone name and date. But, since every dataset has different logical groupings, need to allow different stubs for each dataset.