### PR TITLE
discount for /x/meta routes

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -482,6 +482,10 @@ module.exports.cost = function(url, c, cellprice, metaDiscount, maxbulk){
   let standard_routes = ['argo', 'cchdo', 'drifters', 'tc', 'grids']
 
   if(standard_routes.includes(path[0])){
+    //// metadata routes
+    if(path.length==2 && path[1] == 'meta'){
+      return 0.2
+    }
     //// core data routes
     if(path.length==1 || (path[0]=='grids' && path.length==2 && path[1]!='vocabulary' && path[1]!='meta')){
       ///// any query parameter that specifies a particular record or small set of records can get waived through

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -89,6 +89,18 @@ $RefParser.dereference(rawspec, (err, schema) => {
       it("cost of 15 deg box near equator for 30 years with data for a standard API route should be out of scope", async function () {
         expect(helpers.cost('/argo?startDate=2000-01-01T00:00:00Z&endDate=2030-01-01T00:00:00Z&polygon=[[0,-7.5],[15,-7.5],[15,7.5],[0,7.5],[0,-7.5]]&data=temperature', c, cellprice, metaDiscount, maxbulk).code).to.eql(413);
       });
+    });
+
+    describe("cost functions", function () {
+      it("cost of metadata request should be a flat 0.2", async function () {
+        expect(helpers.cost('/argo/meta?id=4901283_m0', c, cellprice, metaDiscount, maxbulk)).to.eql(0.2);
+      });
+    }); 
+
+    describe("cost functions", function () {
+      it("cost of metadata request should be a flat 0.2", async function () {
+        expect(helpers.cost('/grids/meta?id=ohc_kg', c, cellprice, metaDiscount, maxbulk)).to.eql(0.2);
+      });
     }); 
 }
 


### PR DESCRIPTION
/x/meta routes were previously capped at 1/s; this is both unnecessarily aggressive, and knocks the frontend over when doing regional argo queries that might need metadata from many floats.