### PR TITLE
Data-adjacent variables

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -3988,13 +3988,11 @@ components:
         data_keys:
           $ref: '#/components/schemas/argo_data_keys'
         units:
-          $ref: '#/components/schemas/argo_units'
+          $ref: '#/components/schemas/data_adjacent'
         cycle_number:
           type: number
         data_keys_mode:
-          type: array
-          items:
-            type: string
+          $ref: '#/components/schemas/data_adjacent'
         geolocation_argoqc:
           type: number
         profile_direction:
@@ -4009,9 +4007,7 @@ components:
         data:
         - ""
         - ""
-        data_keys_mode:
-        - data_keys_mode
-        - data_keys_mode
+        data_keys_mode: null
         basin: 0.80082819046101150206595775671303272247314453125
         source:
         - date_updated: 2000-01-23T04:56:07.000+00:00
@@ -4058,7 +4054,7 @@ components:
         data_keys:
           $ref: '#/components/schemas/argo_data_keys'
         units:
-          $ref: '#/components/schemas/argo_units'
+          $ref: '#/components/schemas/data_adjacent'
         country:
           type: string
         data_center:
@@ -4100,7 +4096,7 @@ components:
         _id: _id
         oceanops: oceanops
         fleetmonitoring: fleetmonitoring
-    argo_units:
+    data_adjacent:
       anyOf:
       - type: array
         items:

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -235,16 +235,13 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     }
   }
 
-  // identify data_keys and units, could be on chunk or metadata
+  // identify data_keys, could be on chunk or metadata
   let dk = null
-  let u = null
   if(chunk.hasOwnProperty('data_keys')) {
     dk = chunk.data_keys  
-    u = chunk.units
   }
   else{
     dk = metadata.data_keys
-    u = metadata.units
   }
   // do the same for any other units-like structure in pp_params.data_adjacent
   let da = {}
@@ -269,12 +266,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     coerced_pressure = true
   }
 
-  // turn upstream units into a lookup table by data_key
-  let units = {}
-  for(let k=0; k<dk.length; k++){
-    units[dk[k]] = u[k]
-  }
-  // do the same for each pp_params.data_adjacent
+  // turn data adjacent variables into lookup tables by data_key
   let data_adjacent = {}
   if(pp_params.data_adjacent){
     for (const [key, val] of Object.entries(da)) {
@@ -347,10 +339,9 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     delete chunk.levels
   }
 
-  // manage data_keys, units and any data_adjacent objects
+  // manage data_keys, any data_adjacent objects
   if(keys.includes('all') || !pp_params.data || metadata_only){
     chunk.data_keys = dk
-    chunk.units = units
     if(pp_params.data_adjacent){
       for (const [key, val] of Object.entries(data_adjacent)){
         chunk[key] = val
@@ -359,10 +350,6 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   }
   else if( (keys.length > (coerced_pressure ? 1 : 0))){
     chunk.data_keys = keys
-    chunk.units = units
-    for(const prop in units){
-      if(!keys.includes(prop)) delete chunk.units[prop]
-    }
     if(pp_params.data_adjacent){
       for (const [key, val] of Object.entries(data_adjacent)){
         chunk[key] = val
@@ -388,7 +375,6 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     })
   }
   if(pp_params.compression == 'array'){
-    chunk.units = chunk.data_keys.map(x => chunk.units[x])
     if(pp_params.data_adjacent){
       for(let i=0; i<pp_params.data_adjacent.length; i++){
         chunk[pp_params.data_adjacent[i]] = chunk.data_keys.map(x => chunk[pp_params.data_adjacent[i]][x])

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -348,7 +348,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   }
 
   // manage data_keys, units and any data_adjacent objects
-  if(keys.includes('all') && !metadata_only){
+  if(keys.includes('all') || !pp_params.data || metadata_only){
     chunk.data_keys = dk
     chunk.units = units
     if(pp_params.data_adjacent){
@@ -357,7 +357,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
       }
     }
   }
-  else if( (keys.length > (coerced_pressure ? 1 : 0)) && !metadata_only){
+  else if( (keys.length > (coerced_pressure ? 1 : 0))){
     chunk.data_keys = keys
     chunk.units = units
     for(const prop in units){
@@ -366,9 +366,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     if(pp_params.data_adjacent){
       for (const [key, val] of Object.entries(data_adjacent)){
         chunk[key] = val
-        console.log(key, val, chunk)
         for(const adj_prop in val){
-          console.log(adj_prop)
           if(!keys.includes(adj_prop)) delete chunk[key][adj_prop] 
         }
       }
@@ -388,6 +386,8 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
       }
       return lvl
     })
+  }
+  if(pp_params.compression == 'array'){
     chunk.units = chunk.data_keys.map(x => chunk.units[x])
     if(pp_params.data_adjacent){
       for(let i=0; i<pp_params.data_adjacent.length; i++){

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -152,7 +152,7 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
         data: data,
         presRange: presRange,
         mostrecent: mostrecent,
-        data_adjacent: ['data_keys_mode']
+        data_adjacent: ['units','data_keys_mode']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -151,7 +151,8 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
         compression: compression,
         data: data,
         presRange: presRange,
-        mostrecent: mostrecent
+        mostrecent: mostrecent,
+        data_adjacent: ['data_keys_mode']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -132,7 +132,6 @@ exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,rad
   "metadata" : "metadata",
   "geolocation_argoqc" : 1.4658129805029452,
   "data" : [ "", "" ],
-  "data_keys_mode" : [ "data_keys_mode", "data_keys_mode" ],
   "basin" : 0.8008281904610115,
   "source" : [ {
     "date_updated" : "2000-01-23T04:56:07.000+00:00",
@@ -163,7 +162,6 @@ exports.findArgo = function(id,startDate,endDate,polygon,multipolygon,center,rad
   "metadata" : "metadata",
   "geolocation_argoqc" : 1.4658129805029452,
   "data" : [ "", "" ],
-  "data_keys_mode" : [ "data_keys_mode", "data_keys_mode" ],
   "basin" : 0.8008281904610115,
   "source" : [ {
     "date_updated" : "2000-01-23T04:56:07.000+00:00",

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -71,7 +71,8 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
         compression: compression,
         data: data,
         presRange: presRange,
-        mostrecent: mostrecent
+        mostrecent: mostrecent,
+        data_adjacent: ['units']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -84,7 +84,8 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
         compression: compression,
         data: data,
         presRange: null,
-        mostrecent: mostrecent
+        mostrecent: mostrecent,
+        data_adjacent: ['units']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -67,7 +67,8 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
         compression: compression,
         data: data,
         presRange: presRange,
-        mostrecent: mostrecent
+        mostrecent: mostrecent,
+        data_adjacent: ['units']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -59,7 +59,8 @@ exports.findTC = function(res, id,startDate,endDate,polygon,multipolygon,center,
         compression: compression,
         data: data,
         presRange: null,
-        mostrecent: mostrecent
+        mostrecent: mostrecent,
+        data_adjacent: ['units']
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/spec.json
+++ b/spec.json
@@ -2389,16 +2389,13 @@
                   "$ref": "#/components/schemas/argo_data_keys"
                },
                "units": {
-                  "$ref": "#/components/schemas/argo_units"
+                  "$ref": "#/components/schemas/data_adjacent"
                },
                "cycle_number": {
                   "type": "number"
                },
                "data_keys_mode": {
-                  "type": "array",
-                  "items": {
-                     "type": "string"
-                  }
+                  "$ref": "#/components/schemas/data_adjacent"
                },
                "geolocation_argoqc": {
                   "type": "number"
@@ -2428,7 +2425,7 @@
                   "$ref": "#/components/schemas/argo_data_keys"
                },
                "units": {
-                   "$ref": "#/components/schemas/argo_units"
+                   "$ref": "#/components/schemas/data_adjacent"
                },
                "country": {
                   "type": "string"
@@ -2465,7 +2462,7 @@
                }
             }
          },
-         "argo_units": {
+         "data_adjacent": {
             "anyOf": [
                {
                   "type": "array",

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -222,6 +222,90 @@ $RefParser.dereference(rawspec, (err, schema) => {
     });
 
     describe("GET /argo", function () {
+      it("argo with data filter should return correct data_keys_mode", async function () {
+        const response = await request.get("/argo?id=4901283_021&data=salinity,doxy").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal({'salinity':"D",'doxy':"D",'pressure':"D"})
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with data filter should return correct data_keys_mode, as a list when compressed", async function () {
+        const response = await request.get("/argo?id=4901283_021&data=salinity,doxy&compression=array").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal(["D","D","D"])
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct data_keys on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys).to.deep.equal([ "pressure", "pressure_argoqc", "temperature", "temperature_argoqc" ])
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct units on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018").set({'x-argokey': 'developer'});
+        expect(response.body[0].units).to.deep.equal({"pressure": "decibar", "pressure_argoqc": "null", "temperature":"degree_Celsius", "temperature_argoqc":"null" })
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with data=all filter should return correct units on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018&data=all").set({'x-argokey': 'developer'});
+        expect(response.body[0].units).to.deep.equal({"pressure": "decibar", "pressure_argoqc": "null", "temperature":"degree_Celsius", "temperature_argoqc":"null" })
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct data_keys_mode on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal({"pressure": "R", "pressure_argoqc": "null", "temperature":"R", "temperature_argoqc":"null" })
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with data=metadataOnly filter should still return correct data_keys_mode on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018&data=except-data-values").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal({"pressure": "R", "pressure_argoqc": "null", "temperature":"R", "temperature_argoqc":"null" })
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with compression=array should return correct data_keys_mode on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018&compression=array").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal(["R", "null", "R", "null"])
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with compression=array should return correct units on a core profile", async function () {
+        const response = await request.get("/argo?id=13857_018&compression=array").set({'x-argokey': 'developer'});
+        expect(response.body[0].units).to.deep.equal(["decibar", "null", "degree_Celsius", "null"])
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct data_keys on a bgc profile", async function () {
+        const response = await request.get("/argo?id=4901283_021").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys).to.deep.equal([ "doxy", "doxy_argoqc", "pressure", "pressure_argoqc", "salinity", "salinity_argoqc", "salinity_sfile", "salinity_sfile_argoqc", "temperature", "temperature_argoqc", "temperature_sfile", "temperature_sfile_argoqc" ])
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct units on a bgc profile", async function () {
+        const response = await request.get("/argo?id=4901283_021").set({'x-argokey': 'developer'});
+        expect(response.body[0].units).to.deep.equal({ "doxy": "micromole/kg", "doxy_argoqc": "null", "pressure":"decibar", "pressure_argoqc": "null", "salinity":"psu", "salinity_argoqc":"null", "salinity_sfile":"psu", "salinity_sfile_argoqc":"null", "temperature":"degree_Celsius", "temperature_argoqc":"null", "temperature_sfile": "degree_Celsius", "temperature_sfile_argoqc": "null" })
+      });
+    });
+
+    describe("GET /argo", function () {
+      it("argo with no data filter should still return correct data_keys_mode on a bgc profile", async function () {
+        const response = await request.get("/argo?id=4901283_021").set({'x-argokey': 'developer'});
+        expect(response.body[0].data_keys_mode).to.deep.equal({ "doxy": "D", "doxy_argoqc": "null", "pressure":"D", "pressure_argoqc": "null", "salinity":"D", "salinity_argoqc":"null", "salinity_sfile":"D", "salinity_sfile_argoqc":"null", "temperature":"D", "temperature_argoqc":"null", "temperature_sfile": "D", "temperature_sfile_argoqc": "null" })
+      });
+    });
+
+    describe("GET /argo", function () {
       it("argo with data=all filter should return argo-consistent data", async function () {
         const response = await request.get("/argo?id=4901283_021&data=all").set({'x-argokey': 'developer'});
         expect(response.body).to.be.jsonSchema(schema.paths['/argo'].get.responses['200'].content['application/json'].schema);


### PR DESCRIPTION
Introduces the idea of _data adjacent variables_, the canonical example of which is `units`, another case-specific example of which for Argo is `data_keys_mode`: these are metadata that should be presented as lists sorted per `data_keys` when `compression=array`, or as dictionaries keyed by `data_keys` otherwise.

Note we also change the API behavior here to always return data adjacent variables with data documents, regardless of whether they are stored in data or metadata docs in the db. Harmonizing this schema with the DB would be a good thing to do on next rebuild (ie pull argo core units et al into the data documents; a little bloaty, but only a little and more consistent with BGC schema and API behavior).