### PR TITLE
Templates swagger

### DIFF
--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -14,8 +14,7 @@ info:
 externalDocs:
   description: Find us on GitHub
   url: https://github.com/argovis/argovis_api
-servers:
-- url: /
+servers: []
 security:
 - name: []
 tags:

--- a/nodejs-server/api/openapi.yaml
+++ b/nodejs-server/api/openapi.yaml
@@ -14,7 +14,9 @@ info:
 externalDocs:
   description: Find us on GitHub
   url: https://github.com/argovis/argovis_api
-servers: []
+servers:
+- url: https://argovisbeta01.colorado.edu/api
+- url: /
 security:
 - name: []
 tags:

--- a/spec.json
+++ b/spec.json
@@ -19,8 +19,12 @@
       "url": "https://github.com/argovis/argovis_api"
    },
    "servers": [
-      "https://argovisbeta01.colorado.edu/api",
-      "/"
+      {
+         "url": "https://argovisbeta01.colorado.edu/api"
+      },
+      {
+         "url": "/"
+      }
    ],
    "security": [
       {

--- a/spec.json
+++ b/spec.json
@@ -18,7 +18,10 @@
       "description": "Find us on GitHub",
       "url": "https://github.com/argovis/argovis_api"
    },
-   "servers": [],
+   "servers": [
+      "https://argovisbeta01.colorado.edu/api",
+      "/"
+   ],
    "security": [
       {
          "name": []


### PR DESCRIPTION
A little quirk to how the openapi tooling works: does not like having a sole server URL with an extra path route (like `/api`), but seems to tolerate it if the list of servers ends with `/`. Seems like an upstream bug, but 🤷‍♀️