### PR TITLE
metadata 404 management

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -432,6 +432,7 @@ module.exports.meta_xform = function(res){
     objectMode: true,
     transform(chunk, encoding, next){
       this.push(chunk)
+      nDocs++
       next()
     }
   });
@@ -439,6 +440,7 @@ module.exports.meta_xform = function(res){
   postprocess._flush = function(callback){
     if(nDocs == 0){
       res.status(404)
+      this.push({"code":404, "message": "No documents found matching search."})
     }
     return callback()
   }

--- a/nodejs-server/service/FloatLocationForecastService.js
+++ b/nodejs-server/service/FloatLocationForecastService.js
@@ -96,6 +96,12 @@ exports.findfloatLocationForecast = function(res, id,forecastOrigin,forecastGeol
  **/
 exports.findfloatLocationForecastMeta = function(res,id) {
   return new Promise(function(resolve, reject) {
+    if(id !== 'covariance'){
+      reject({
+        code: 404,
+        message: "No float location metadata matching ID " + id + "; all float location metadata is stored in the single document id=covariance"
+      })
+    }
     const query = floatLocationForecast['floatLocationForecastMeta'].aggregate([{$match:{'_id':id}}]);
     let postprocess = helpers.meta_xform(res)
     resolve([query.cursor(), postprocess])

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -15,7 +15,14 @@ const summaries = require('../models/summary');
 
 exports.findgridMeta = function(res,id) {
   return new Promise(function(resolve, reject) {
-    const query = Grid[helpers.find_grid_collection(id)+'Meta'].aggregate([{$match:{'_id':id}}]);
+    let gridCollection = helpers.find_grid_collection(id)
+    if(gridCollection === ''){
+      reject({
+        code: 404,
+        message: "No grid product matching ID " + id
+      })
+    }
+    const query = Grid[gridCollection + 'Meta'].aggregate([{$match:{'_id':id}}]);
     let postprocess = helpers.meta_xform(res)
     resolve([query.cursor(), postprocess])
   });

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -192,6 +192,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body.length).to.eql(10);
       });
     });     
+
+    describe("GET /drifters/meta", function () {
+      it("should 404 on ID typos", async function () {
+        const response = await request.get("/drifters/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql([{"code": 404,"message": "No documents found matching search."}])
+      });
+    });
   }
 })
 

--- a/tests/tests/floatLocationForecast.tests.js
+++ b/tests/tests/floatLocationForecast.tests.js
@@ -83,6 +83,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body).to.be.jsonSchema(schema.paths['/floatLocationForecast/meta'].get.responses['200'].content['application/json'].schema);
       });
     });
+
+    describe("GET /floatLocationForecast/meta", function () {
+      it("floatLocationForecast metadata 404", async function () {
+        const response = await request.get("/floatLocationForecast/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql({code: 404,message: "No float location metadata matching ID xxx; all float location metadata is stored in the single document id=covariance"});
+      });
+    }); 
   }
 })
 

--- a/tests/tests/grid.tests.js
+++ b/tests/tests/grid.tests.js
@@ -173,6 +173,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /grids/meta", function () {
+      it("grid metadata 404", async function () {
+        const response = await request.get("/grids/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql({code: 404,message: "No grid product matching ID xxx"});
+      });
+    }); 
+
     describe("GET /grids/grid_1_1_0.5_0.5", function () {
       it("fetch gridded data with pressure bracket", async function () {
         const response = await request.get("/grids/grid_1_1_0.5_0.5?id=20040115000000_20.5_-64.5&presRange=10,100&data=rg09_temperature&compression=array").set({'x-argokey': 'developer'});

--- a/tests/tests/profiles.tests.js
+++ b/tests/tests/profiles.tests.js
@@ -163,6 +163,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /cchdo/meta", function () {
+      it("should 404 on ID typos", async function () {
+        const response = await request.get("/cchdo/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql([{"code": 404,"message": "No documents found matching search."}])
+      });
+    });
+
     // argo
 
     describe("GET /argo", function () {
@@ -480,6 +488,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       it("should return profiles in presRange, even if not returning actual data levels", async function () {
         const response = await request.get("/argo?presRange=1000,2000").set({'x-argokey': 'developer'});
         expect(response.body.length).to.eql(3);
+      });
+    });
+
+    describe("GET /argo/meta", function () {
+      it("should 404 on ID typos", async function () {
+        const response = await request.get("/argo/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql([{"code": 404,"message": "No documents found matching search."}])
       });
     });
 

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -144,6 +144,14 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     }); 
 
+    describe("GET /tc/meta", function () {
+      it("should 404 on ID typos", async function () {
+        const response = await request.get("/tc/meta?id=xxx").set({'x-argokey': 'developer'});
+        expect(response.status).to.eql(404);
+        expect(response.body).to.eql([{"code": 404,"message": "No documents found matching search."}])
+      });
+    });
+
   }
 })
 


### PR DESCRIPTION
`<x>/meta` routes were doing several different wrong things when searched for a document ID not found in the database; this PR corrects and normalizes this to the data route behavior (response code 404, and a human readable JSON message explaining what happened).