### PR TITLE
managing data_keys and data-adjacent variables

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -4,5 +4,6 @@ COPY tests/package.json .
 RUN npm install
 COPY tests .
 COPY nodejs-server/helpers/helpers.js tests/helpers.js
+COPY nodejs-server/helpers/gridHelpers.js tests/gridHelpers.js
 COPY spec.json .
 CMD npm test

--- a/nodejs-server/helpers/gridHelpers.js
+++ b/nodejs-server/helpers/gridHelpers.js
@@ -182,3 +182,13 @@ module.exports.grid_post_xform = function(pp_params, search_result, res, stub){
 
   return postprocess
 }
+
+module.exports.find_grid_collection = function(token){
+  // map a token including a grid's prefix ('rg09_temperature', 'rg09_salinity', ...) onto its collection name.
+
+  if (["rg09_temperature", "rg09_salinity", "kg21_ohc15to300"].some(k => token.includes(k))) {
+    return 'grid_1_1_0.5_0.5'
+  } else {
+    return ''
+  }
+}

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -639,13 +639,3 @@ module.exports.source_filter = function(sourcelist){
   return {$match: sourcematch}
 }
 
-module.exports.find_grid_collection = function(token){
-  // map a token including a grid's prefix ('rg09_temperature', 'rg09_salinity', ...) onto its collection name.
-
-  if (["rg09_temperature", "rg09_salinity", "kg21_ohc15to300"].some(k => token.includes(k))) {
-    return 'grid_1_1_0.5_0.5'
-  } else {
-    return ''
-  }
-}
-

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -334,8 +334,8 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
     delete chunk.levels
   }
 
-  // manage data_keys, any data_adjacent objects
-  if(keys.includes('all') || !pp_params.data || metadata_only){
+  // manage data_keys, any data_adjacent objects, when pp_params.data is defined or forced by always_import
+  if(keys.includes('all') || (!pp_params.data && pp_params.always_import)){
     chunk.data_keys = dk
     if(pp_params.data_adjacent){
       for (const [key, val] of Object.entries(data_adjacent)){
@@ -343,7 +343,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
       }
     }
   }
-  else if( (keys.length > (coerced_pressure ? 1 : 0))){
+  else if(keys.length > 0) {
     chunk.data_keys = keys
     if(pp_params.data_adjacent){
       for (const [key, val] of Object.entries(data_adjacent)){
@@ -369,10 +369,12 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
       return lvl
     })
   }
-  if(pp_params.compression == 'array'){
+  if(pp_params.compression == 'array' && chunk.data_keys){
     if(pp_params.data_adjacent){
       for(let i=0; i<pp_params.data_adjacent.length; i++){
-        chunk[pp_params.data_adjacent[i]] = chunk.data_keys.map(x => chunk[pp_params.data_adjacent[i]][x])
+        if(chunk[pp_params.data_adjacent[i]]){
+          chunk[pp_params.data_adjacent[i]] = chunk.data_keys.map(x => chunk[pp_params.data_adjacent[i]][x])
+        }
       }
     }
   }

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -152,7 +152,8 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
         data: JSON.stringify(data) === '["except-data-values"]' ? null : data, // ie `data=except-data-values` is the same as just omitting the data qsp
         presRange: presRange,
         mostrecent: mostrecent,
-        data_adjacent: ['units','data_keys_mode']
+        data_adjacent: ['units','data_keys_mode'],
+        always_import: true // add data_keys and everything in data_adjacent to data docs, no matter what
     }
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -15,7 +15,7 @@ const summaries = require('../models/summary');
 
 exports.findgridMeta = function(res,id) {
   return new Promise(function(resolve, reject) {
-    let gridCollection = helpers.find_grid_collection(id)
+    let gridCollection = gridHelpers.find_grid_collection(id)
     if(gridCollection === ''){
       reject({
         code: 404,

--- a/tests/tests/drifters.tests.js
+++ b/tests/tests/drifters.tests.js
@@ -200,6 +200,20 @@ $RefParser.dereference(rawspec, (err, schema) => {
         expect(response.body).to.eql([{"code": 404,"message": "No documents found matching search."}])
       });
     });
+
+    describe("GET /drifters", function () {
+      it("drifters with no data filter should not inclde data_keys on the data document", async function () {
+        const response = await request.get("/drifters?id=101143_0").set({'x-argokey': 'developer'});
+        expect(response.body[0].hasOwnProperty('data_keys')).to.eql(false);  
+      });
+    }); 
+
+    describe("GET /drifters", function () {
+      it("drifters with no data filter should not inclde units on the data document", async function () {
+        const response = await request.get("/drifters?id=101143_0").set({'x-argokey': 'developer'});
+        expect(response.body[0].hasOwnProperty('units')).to.eql(false);  
+      });
+    }); 
   }
 })
 

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -6,6 +6,7 @@ chai.use(require('chai-almost')(0.00000001));
 const rawspec = require('/tests/spec.json');
 const $RefParser = require("@apidevtools/json-schema-ref-parser");
 const helpers = require('/tests/tests/helpers')
+const gridHelpers = require('/tests/tests/gridHelpers')
 
 const c = 1
 const cellprice = 0.0001
@@ -105,7 +106,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("grid prefixes", function () {
       it('checks mapping between grid names and collection names', async function () {
-        expect(helpers.find_grid_collection('rg09_temperature_200401_Total')).to.eql('grid_1_1_0.5_0.5');
+        expect(gridHelpers.find_grid_collection('rg09_temperature_200401_Total')).to.eql('grid_1_1_0.5_0.5');
       });
     });
 }

--- a/tests/tests/tc.tests.js
+++ b/tests/tests/tc.tests.js
@@ -152,6 +152,19 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });
 
+    describe("GET /tc", function () {
+      it("tc with no data filter should not inclde data_keys on the data document", async function () {
+        const response = await request.get("/tc?id=AL011851_18510625000000").set({'x-argokey': 'developer'});
+        expect(response.body[0].hasOwnProperty('data_keys')).to.eql(false);  
+      });
+    }); 
+
+    describe("GET /tc", function () {
+      it("tc with no data filter should not inclde units on the data document", async function () {
+        const response = await request.get("/tc?id=AL011851_18510625000000").set({'x-argokey': 'developer'});
+        expect(response.body[0].hasOwnProperty('units')).to.eql(false);  
+      });
+    }); 
   }
 })
 


### PR DESCRIPTION
Some time ago, we decided that core argo profiles should always be returned with data_keys and units on the data document to match argo BGC profiles, even though in the database these variables live on the metadata docs for argo core. The previous implementation accomplished this - but also inserted those variables in the data docs for tropical cyclones (wasteful), and drifters (extremely wasteful). This PR allows product-specific behavior by introducing the `pp_params.always_import` flag, which forces the import of `data_keys` and anything in `pp_params.data_adjacent` to the data doc, per the desired behavior for argo.