### PR TITLE
perf improvement when using data=all

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -343,7 +343,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   }
 
   // drop any level for which all requested measurements are null if specific data has been requested
-  if(pp_params.data){
+  if(pp_params.data && pp_params.data != 'all'){
     let dcopy = JSON.parse(JSON.stringify(chunk.data))
     if(coerced_pressure){
       dcopy.splice(chunk.data_info[0].indexOf('pressure'),1)

--- a/nodejs-server/package.json
+++ b/nodejs-server/package.json
@@ -4,7 +4,7 @@
   "description": "REST API for Argo profiles, platforms, selections, BGC data, gridded products, etc.",
   "main": "index.js",
   "scripts": {
-	"start": "node index.js"
+  "start": "node index.js"
   },
   "keywords": [
     "swagger"


### PR DESCRIPTION
avoids the code path where we check and make sure we have the data we asked for when we didn't actually ask for anything specific; will significantly speed up frontend plotting page, for example.