### PR TITLE
Server projection

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -150,10 +150,11 @@ module.exports.request_sanitation = function(polygon, center, radius, multipolyg
   return false
 }
 
-module.exports.datatable_stream = function(model, params, local_filter, foreign_docs){
+module.exports.datatable_stream = function(model, params, local_filter, projection, foreign_docs){
   // given <model>, a mongoose model pointing to a data collection,
   // <params> the return object from parameter_sanitization,
   // <local_filter> a custom set of aggregation pipeline steps to be applied to the data collection reffed by <model>,
+  // <projection> a list of data document keys to project down to at the end of the search
   // and <foreign_docs>, an array of documents matching a query on the metadata collection which should constrain which data collection docs we return,
   // return a cursor over that which matches the above
 
@@ -202,6 +203,16 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
   let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch)
   aggPipeline.push({$sort: {'timestamp':-1}})
 
+  if(projection){
+    // drop documents with no data before the come out of the DB, and project out only the listed data document keys
+    aggPipeline.push({$match: {'data.0':{$exists:true}}})
+    project = {}
+    for(let i=0;i<projection.length;i++){
+      project[projection[i]] = 1
+    }
+    aggPipeline.push({$project: project})
+  }
+
   return model.aggregate(aggPipeline).cursor()
 }
 
@@ -222,6 +233,11 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   // <stub>: function accepting one data document and its corresponding metadata document, returns appropriate representation for the compression=minimal flag.
   // returns chunk mutated into its final, user-facing form
   // or return false to drop this item from the stream
+
+  // return a minimal stub if requested
+  if(pp_params.skip_data_filter){
+    return stub(chunk, metadata)
+  }
 
   // declare some variables at scope
   let keys = []       // data keys to keep when filtering down data

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -204,7 +204,7 @@ module.exports.datatable_stream = function(model, params, local_filter, projecti
   aggPipeline.push({$sort: {'timestamp':-1}})
 
   if(projection){
-    // drop documents with no data before the come out of the DB, and project out only the listed data document keys
+    // drop documents with no data before they come out of the DB, and project out only the listed data document keys
     aggPipeline.push({$match: {'data.0':{$exists:true}}})
     project = {}
     for(let i=0;i<projection.length;i++){
@@ -234,8 +234,8 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   // returns chunk mutated into its final, user-facing form
   // or return false to drop this item from the stream
 
-  // return a minimal stub if requested
-  if(pp_params.skip_data_filter){
+  // immediately return a minimal stub if requested and data has been projected off
+  if(pp_params.compression == 'minimal' && !chunk.hasOwnProperty('data')){
     return stub(chunk, metadata)
   }
 

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -155,6 +155,7 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
         always_import: true, // add data_keys and everything in data_adjacent to data docs, no matter what
         suppress_meta: compression=='minimal' // don't need to look up metadata if making a minimal request
     }
+    pp_params.skip_data_filter = compression=='minimal' && pp_params.data==null
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
@@ -171,7 +172,7 @@ exports.findArgo = function(res, id,startDate,endDate,polygon,multipolygon,cente
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, argo['argo'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, argo['argo'], params, local_filter, ['_id', 'metadata', 'geolocation', 'timestamp', 'source']))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -80,6 +80,12 @@ exports.findArgoTrajectory = function(res,id,startDate,endDate,polygon,multipoly
         mostrecent: mostrecent
     }
 
+    // can we afford to project data documents down to a subset in aggregation?
+    let projection = null
+    if(compression=='minimal' && data==null){
+      projection = ['_id', 'metadata', 'geolocation', 'timestamp']
+    }
+
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
     let metacomplete = false
@@ -89,7 +95,7 @@ exports.findArgoTrajectory = function(res,id,startDate,endDate,polygon,multipoly
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, trajectories['argotrajectories'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, trajectories['argotrajectories'], params, local_filter, projection))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -73,6 +73,12 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
         mostrecent: mostrecent
     }
 
+    // can we afford to project data documents down to a subset in aggregation?
+    let projection = null
+    if(compression=='minimal' && data==null && presRange==null){
+      projection = ['_id', 'metadata', 'geolocation', 'timestamp', 'source']
+    }
+
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
     let metacomplete = false
@@ -88,7 +94,7 @@ exports.findCCHDO = function(res, id,startDate,endDate,polygon,multipolygon,cent
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, cchdo['cchdo'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, cchdo['cchdo'], params, local_filter, projection))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -86,6 +86,12 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
         mostrecent: mostrecent
     }
 
+    // can we afford to project data documents down to a subset in aggregation?
+    let projection = null
+    if(compression=='minimal' && data==null){
+      projection = ['_id', 'metadata', 'geolocation', 'timestamp']
+    }
+
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
     let metacomplete = false
@@ -101,7 +107,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,c
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Drifter['drifter'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Drifter['drifter'], params, local_filter, projection))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -76,12 +76,18 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
         mostrecent: mostrecent
     }
 
+    // can we afford to project data documents down to a subset in aggregation?
+    let projection = null
+    if(compression=='minimal' && data==null && presRange==null){
+      projection = ['_id', 'metadata', 'geolocation', 'timestamp']
+    }
+
     // metadata table filter: no-op promise stub, nothing to filter grid data docs on from metadata at the moment
     let metafilter = Promise.resolve([])
     let metacomplete = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Grid[gridName], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Grid[gridName], params, local_filter, projection))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {


### PR DESCRIPTION
Turns out it's much faster to have Mongo drop fields you aren't going to use, than to deserialize everything and do it in node.