### PR TITLE
api logging server logic

### DIFF
--- a/core-spec.json
+++ b/core-spec.json
@@ -67,9 +67,43 @@
       {
          "name": "token",
          "description": "token validation"
+      },
+      {
+         "name": "ping",
+         "description": "ping for liveness"
       }
    ],
    "paths": {
+      "/ping": {
+         "get": {
+            "tags": [
+               "ping"
+            ],
+            "summary": "Dummy endpoint for liveness checks",
+            "operationId": "ping",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "string"
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
       "/ar": {
          "get": {
             "tags": [

--- a/core-spec.json
+++ b/core-spec.json
@@ -85,9 +85,10 @@
                "200": {
                   "description": "OK",
                   "content": {
-                     "application/json": {
+                     "text/plain": {
                         "schema": {
-                           "type": "string"
+                           "type": "string",
+                           "example": "OK"
                         }
                      }
                   }

--- a/miami-spec.json
+++ b/miami-spec.json
@@ -61,9 +61,10 @@
                "200": {
                   "description": "OK",
                   "content": {
-                     "application/json": {
+                     "text/plain": {
                         "schema": {
-                           "type": "string"
+                           "type": "string",
+                           "example": "OK"
                         }
                      }
                   }

--- a/miami-spec.json
+++ b/miami-spec.json
@@ -43,9 +43,43 @@
       {
          "name": "token",
          "description": "token validation"
+      },
+      {
+         "name": "ping",
+         "description": "ping for liveness"
       }
    ],
    "paths": {
+      "/ping": {
+         "get": {
+            "tags": [
+               "ping"
+            ],
+            "summary": "Dummy endpoint for liveness checks",
+            "operationId": "ping",
+            "responses": {
+               "200": {
+                  "description": "OK",
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "type": "string"
+                        }
+                     }
+                  }
+               },
+               "400": {
+                  "$ref": "#/components/responses/badRequest"
+               },
+               "404": {
+                  "$ref": "#/components/responses/notFound"
+               },
+               "500": {
+                  "$ref": "#/components/responses/serverError"
+               }
+            }
+         }
+      },
       "/drifters": {
          "get": {
             "tags": [

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -52,10 +52,11 @@ paths:
         "200":
           description: OK
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
-                x-content-type: application/json
+                example: OK
+                x-content-type: text/plain
         "400":
           description: Bad Request
           content:

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -39,7 +39,42 @@ tags:
   description: Trajectories of argo floats
 - name: token
   description: token validation
+- name: ping
+  description: ping for liveness
 paths:
+  /ping:
+    get:
+      tags:
+      - ping
+      summary: Dummy endpoint for liveness checks
+      operationId: ping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                x-content-type: application/json
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Ping
   /ar:
     get:
       tags:

--- a/nodejs-server/api/openapi.miami.yaml
+++ b/nodejs-server/api/openapi.miami.yaml
@@ -25,7 +25,42 @@ tags:
   description: Summary statistics (mostly for internal use)
 - name: token
   description: token validation
+- name: ping
+  description: ping for liveness
 paths:
+  /ping:
+    get:
+      tags:
+      - ping
+      summary: Dummy endpoint for liveness checks
+      operationId: ping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+                x-content-type: application/json
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "404":
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorResponse'
+      x-swagger-router-controller: Ping
   /drifters:
     get:
       tags:

--- a/nodejs-server/api/openapi.miami.yaml
+++ b/nodejs-server/api/openapi.miami.yaml
@@ -38,10 +38,11 @@ paths:
         "200":
           description: OK
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
-                x-content-type: application/json
+                example: OK
+                x-content-type: text/plain
         "400":
           description: Bad Request
           content:

--- a/nodejs-server/controllers/ArExperimental.js
+++ b/nodejs-server/controllers/ArExperimental.js
@@ -1,9 +1,12 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var ArExperimental = require('../service/ArExperimentalService');
 
 module.exports.findAR = function findAR (req, res, next, date, _id) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   ArExperimental.findAR(date, _id)
     .then(function (response) {
       utils.writeJson(res, response, 200);

--- a/nodejs-server/controllers/Argo.js
+++ b/nodejs-server/controllers/Argo.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/ArgoService');
 var helpers = require('../helpers/helpers')
 
 module.exports.argoBGC = function argoBGC (req, res, next) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.argoBGC()
     .then(function (response) {
       utils.writeJson(res, response);
@@ -18,6 +21,9 @@ module.exports.argoBGC = function argoBGC (req, res, next) {
 };
 
 module.exports.argoDACs = function argoDACs (req, res, next) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.argoDACs()
     .then(function (response) {
       utils.writeJson(res, response);
@@ -31,6 +37,9 @@ module.exports.argoDACs = function argoDACs (req, res, next) {
 };
 
 module.exports.argoOverview = function argoOverview (req, res, next) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.argoOverview()
     .then(function (response) {
       utils.writeJson(res, response);
@@ -44,6 +53,9 @@ module.exports.argoOverview = function argoOverview (req, res, next) {
 };
 
 module.exports.argoVocab = function argoVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.argoVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);
@@ -57,6 +69,9 @@ module.exports.argoVocab = function argoVocab (req, res, next, parameter) {
 };
 
 module.exports.findArgo = function findArgo (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, platform, platform_type, source, compression, mostrecent, data, presRange) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.findArgo(res, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, platform, platform_type, source, compression, mostrecent, data, presRange)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -68,6 +83,9 @@ module.exports.findArgo = function findArgo (req, res, next, id, startDate, endD
 };
 
 module.exports.findArgometa = function findArgometa (req, res, next, id, platform) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Profiles.findArgometa(res, id, platform)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {

--- a/nodejs-server/controllers/ArgoTrajectoriesExperimental.js
+++ b/nodejs-server/controllers/ArgoTrajectoriesExperimental.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var ArgoTrajectoriesExperimental = require('../service/ArgoTrajectoriesExperimentalService');
 var helpers = require('../helpers/helpers')
 
 module.exports.argotrajectoryVocab = function argotrajectoryVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   ArgoTrajectoriesExperimental.argotrajectoryVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);
@@ -18,6 +21,9 @@ module.exports.argotrajectoryVocab = function argotrajectoryVocab (req, res, nex
 };
 
 module.exports.findArgoTrajectory = function findArgoTrajectory (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, platform, compression, mostrecent, data) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   ArgoTrajectoriesExperimental.findArgoTrajectory(res, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, platform, compression, mostrecent, data)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -29,6 +35,9 @@ module.exports.findArgoTrajectory = function findArgoTrajectory (req, res, next,
 };
 
 module.exports.findArgotrajectorymeta = function findArgotrajectorymeta (req, res, next, id, platform) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   ArgoTrajectoriesExperimental.findArgotrajectorymeta(res, id, platform)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {

--- a/nodejs-server/controllers/Argone.js
+++ b/nodejs-server/controllers/Argone.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Argone = require('../service/ArgoneService');
 var helpers = require('../helpers/helpers')
 
 module.exports.findargone = function findargone (req, res, next, id, forecastOrigin, forecastGeolocation, metadata, compression, data) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Argone.findargone(res, id, forecastOrigin, forecastGeolocation, metadata, compression, data)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -16,6 +19,9 @@ module.exports.findargone = function findargone (req, res, next, id, forecastOri
 };
 
 module.exports.findargoneMeta = function findargoneMeta (req, res, next, id) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Argone.findargoneMeta(res, id)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {

--- a/nodejs-server/controllers/Cchdo.js
+++ b/nodejs-server/controllers/Cchdo.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Profiles = require('../service/CchdoService');
 var helpers = require('../helpers/helpers')
 
 module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.findCCHDO(res, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, woceline, cchdo_cruise, source, compression, mostrecent, data, presRange)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -16,6 +19,9 @@ module.exports.findCCHDO = function findCCHDO (req, res, next, id, startDate, en
 };
 
 module.exports.findCCHDOmeta = function findCCHDOmeta (req, res, next, id, woceline, cchdo_cruise) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Profiles.findCCHDOmeta(res, id, woceline, cchdo_cruise)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -27,6 +33,9 @@ module.exports.findCCHDOmeta = function findCCHDOmeta (req, res, next, id, wocel
 };
 
 module.exports.cchdoVocab = function cchdoVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Profiles.cchdoVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Drifters.js
+++ b/nodejs-server/controllers/Drifters.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Drifters = require('../service/DriftersService');
 var helpers = require('../helpers/helpers')
 
 module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, id, platform, wmo) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Drifters.drifterMetaSearch(res,id,platform, wmo)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -16,6 +19,9 @@ module.exports.drifterMetaSearch = function drifterMetaSearch (req, res, next, i
 };
 
 module.exports.drifterSearch = function drifterSearch (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, wmo, platform, compression, mostrecent, data) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Drifters.drifterSearch(res,id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, wmo, platform, compression, mostrecent, data)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -27,6 +33,9 @@ module.exports.drifterSearch = function drifterSearch (req, res, next, id, start
 };
 
 module.exports.drifterVocab = function drifterVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Drifters.drifterVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Grid = require('../service/GridService');
 var helpers = require('../helpers/helpers')
 
 module.exports.findgrid = function findgrid (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data, presRange, gridName) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Grid.findgrid(res,gridName, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data, presRange)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -16,6 +19,9 @@ module.exports.findgrid = function findgrid (req, res, next, id, startDate, endD
 };
 
 module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Grid.findgridMeta(res,id)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -27,6 +33,9 @@ module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
 };
 
 module.exports.gridVocab = function gridVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Grid.gridVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Ping.js
+++ b/nodejs-server/controllers/Ping.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var utils = require('../utils/writer.js');
+var Ping = require('../service/PingService');
+
+module.exports.ping = function ping (req, res, next) {
+  Ping.ping()
+    .then(function (response) {
+      utils.writeJson(res, response);
+    })
+    .catch(function (response) {
+      utils.writeJson(res, response);
+    });
+};

--- a/nodejs-server/controllers/Ping.js
+++ b/nodejs-server/controllers/Ping.js
@@ -6,7 +6,10 @@ var Ping = require('../service/PingService');
 module.exports.ping = function ping (req, res, next) {
   Ping.ping()
     .then(function (response) {
-      utils.writeJson(res, response);
+      utils.writeJson(res, response, 200);
+    },
+    function (response) {
+      utils.writeJson(res, response, response.code);
     })
     .catch(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/SummaryExperimental.js
+++ b/nodejs-server/controllers/SummaryExperimental.js
@@ -1,10 +1,13 @@
 'use strict';
+const apihits = require('../models/apihits');
 var helpers = require('../helpers/helpers')
-
 var utils = require('../utils/writer.js');
 var SummaryExperimental = require('../service/SummaryExperimentalService');
 
 module.exports.fetchSummary = function fetchSummary (req, res, next, id) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   SummaryExperimental.fetchSummary(id)
     .then(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Tc.js
+++ b/nodejs-server/controllers/Tc.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Tc = require('../service/TcService');
 var helpers = require('../helpers/helpers')
 
 module.exports.findTC = function findTC (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, name, mostrecent, compression, data) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Tc.findTC(res, id, startDate, endDate, polygon, multipolygon, winding, center, radius, metadata, name, mostrecent, compression, data)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -16,6 +19,9 @@ module.exports.findTC = function findTC (req, res, next, id, startDate, endDate,
 };
 
 module.exports.findTCmeta = function findTCmeta (req, res, next, id, name) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+
   Tc.findTCmeta(res,id,name)
    .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {
@@ -27,6 +33,9 @@ module.exports.findTCmeta = function findTCmeta (req, res, next, id, name) {
 };
 
 module.exports.tcVocab = function tcVocab (req, res, next, parameter) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Tc.tcVocab(parameter)
     .then(function (response) {
       utils.writeJson(res, response);

--- a/nodejs-server/controllers/Token.js
+++ b/nodejs-server/controllers/Token.js
@@ -1,10 +1,13 @@
 'use strict';
-
+const apihits = require('../models/apihits');
 var utils = require('../utils/writer.js');
 var Token = require('../service/TokenService');
 var helpers = require('../helpers/helpers')
 
 module.exports.validateToken = function validateToken (req, res, next, token) {
+
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  
   Token.validateToken(res, token)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
     function (response) {

--- a/nodejs-server/models/apihits.js
+++ b/nodejs-server/models/apihits.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const apihits = Schema({
+	metadata: {type: String, required: true},
+	query: {type:Schema.Types.Mixed, required: false}
+}, { timestamps: {createdAt: 'timestamp'} })
+
+module.exports = {}
+module.exports.apihits = mongoose.model('apihits', apihits, 'apihits');

--- a/nodejs-server/service/PingService.js
+++ b/nodejs-server/service/PingService.js
@@ -9,7 +9,7 @@
 exports.ping = function() {
   return new Promise(function(resolve, reject) {
     var examples = {};
-    examples['application/json'] = "";
+    examples['application/json'] = "OK";
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {

--- a/nodejs-server/service/PingService.js
+++ b/nodejs-server/service/PingService.js
@@ -8,13 +8,8 @@
  **/
 exports.ping = function() {
   return new Promise(function(resolve, reject) {
-    var examples = {};
-    examples['application/json'] = "";
-    if (Object.keys(examples).length > 0) {
-      resolve(examples[Object.keys(examples)[0]]);
-    } else {
-      resolve();
-    }
+      resolve('OK')
+      return
   });
 }
 

--- a/nodejs-server/service/PingService.js
+++ b/nodejs-server/service/PingService.js
@@ -1,0 +1,20 @@
+'use strict';
+
+
+/**
+ * Dummy endpoint for liveness checks
+ *
+ * returns String
+ **/
+exports.ping = function() {
+  return new Promise(function(resolve, reject) {
+    var examples = {};
+    examples['application/json'] = "";
+    if (Object.keys(examples).length > 0) {
+      resolve(examples[Object.keys(examples)[0]]);
+    } else {
+      resolve();
+    }
+  });
+}
+


### PR DESCRIPTION
 - all API endpoints now log hits in an `apihits` collection in mongodb. Only route, query string, and timestamp are logged, no personally identifying information is even considered to make sure we stay on the good side of the GDPR.
 - added a dummy `/ping` endpoint for the kubernetes liveness probes; the endpoint isn't logged in mongodb, so we avoid spamming the logs.