### PR TITLE
grid summaries

### DIFF
--- a/core-spec.json
+++ b/core-spec.json
@@ -568,6 +568,17 @@
             ],
             "summary": "List data and lattice for the requested grid.",
             "operationId": "gridVocab",
+            "parameters": [
+               {
+                  "name": "gridName",
+                  "in": "path",
+                  "required": "true",
+                  "schema": {
+                     "type": "string",
+                     "enum": ["rg09", "kg21"]
+                  }
+               }
+            ],
             "responses": {
                "200": {
                   "description": "OK",

--- a/core-spec.json
+++ b/core-spec.json
@@ -561,25 +561,13 @@
             }
          }
       },
-      "/grids/vocabulary": {
+      "/grids/{gridName}/vocabulary": {
          "get": {
             "tags": [
                "grid"
             ],
-            "summary": "List all grid names currently available",
+            "summary": "List data and lattice for the requested grid.",
             "operationId": "gridVocab",
-            "parameters": [
-               {
-                  "in": "query",
-                  "name": "parameter",
-                  "required": true,
-                  "description": "Grid path or query string parameter to summarize possible values of.",
-                  "schema": {
-                     "type": "string",
-                     "enum": ["gridName"]
-                  }
-               }
-            ],
             "responses": {
                "200": {
                   "description": "OK",

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -804,6 +804,17 @@ paths:
       - grid
       summary: List data and lattice for the requested grid.
       operationId: gridVocab
+      parameters:
+      - name: gridName
+        in: path
+        required: true
+        style: simple
+        explode: false
+        schema:
+          type: string
+          enum:
+          - rg09
+          - kg21
       responses:
         "200":
           description: OK

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -798,24 +798,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorResponse'
       x-swagger-router-controller: Grid
-  /grids/vocabulary:
+  /grids/{gridName}/vocabulary:
     get:
       tags:
       - grid
-      summary: List all grid names currently available
+      summary: List data and lattice for the requested grid.
       operationId: gridVocab
-      parameters:
-      - name: parameter
-        in: query
-        description: Grid path or query string parameter to summarize possible values
-          of.
-        required: true
-        style: form
-        explode: true
-        schema:
-          type: string
-          enum:
-          - gridName
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -23,8 +23,8 @@ module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
     });
 };
 
-module.exports.gridVocab = function gridVocab (req, res, next) {
-  Grid.gridVocab()
+module.exports.gridVocab = function gridVocab (req, res, next, gridName) {
+  Grid.gridVocab(gridName)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -23,8 +23,8 @@ module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
     });
 };
 
-module.exports.gridVocab = function gridVocab (req, res, next, parameter) {
-  Grid.gridVocab(parameter)
+module.exports.gridVocab = function gridVocab (req, res, next) {
+  Grid.gridVocab()
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -106,12 +106,11 @@ exports.findgridMeta = function(id) {
 
 
 /**
- * List all grid names currently available
+ * List data and lattice for the requested grid.
  *
- * parameter String Grid path or query string parameter to summarize possible values of.
  * returns List
  **/
-exports.gridVocab = function(parameter) {
+exports.gridVocab = function() {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -108,9 +108,10 @@ exports.findgridMeta = function(id) {
 /**
  * List data and lattice for the requested grid.
  *
+ * gridName String 
  * returns List
  **/
-exports.gridVocab = function() {
+exports.gridVocab = function(gridName) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ "", "" ];


### PR DESCRIPTION
Looking back, the current strategy for the grid vocab route is silly: it returns one global document for all the grids. This PR lets the user select the grid they want vocab for, returning the documents created in https://github.com/argovis/grid-sync/pull/14