### PR TITLE
be inclusive of final date when endDate not specified

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -726,20 +726,21 @@ module.exports.earliest_records = function(dataset){
 }
 
 module.exports.final_records = function(dataset){
-  // return a date representing the last record for the named dataset
+  // return a date representing the last record for the named dataset, plus 1s
+  // (used to coerce in an endDate when none provided, in which case we want to be inclusive of the last date as opposed to our usual exclusive, hence the +1s)
 
   let dates = {
     'argo': new Date(),
-    'cchdo': new Date("2023-03-09T17:48:00Z"),
-    'drifters': new Date("2020-06-30T23:00:00Z"),
-    'kg21': new Date("2020-12-15T00:00:00Z"),
-    'rg09': new Date("2022-05-15T00:00:00Z"),
-    'tc': new Date("2020-12-25T12:00:00Z"),
-    'trajectories': new Date("2021-01-01T01:13:26Z"),
-    'noaasst': new Date("2023-01-29T00:00:00.000Z"),
-    'copernicussla': new Date("2022-07-31T00:00:00.000Z"),
-    'ccmpwind': new Date("1993-12-26T00:00:00Z"),
-    'glodap': new Date('0001-01-02T00:00:00Z')
+    'cchdo': new Date("2023-03-09T17:48:01Z"),
+    'drifters': new Date("2020-06-30T23:00:01Z"),
+    'kg21': new Date("2020-12-15T00:00:01Z"),
+    'rg09': new Date("2022-05-15T00:00:01Z"),
+    'tc': new Date("2020-12-25T12:00:01Z"),
+    'trajectories': new Date("2021-01-01T01:13:27Z"),
+    'noaasst': new Date("2023-01-29T00:00:01Z"),
+    'copernicussla': new Date("2022-07-31T00:00:01Z"),
+    'ccmpwind': new Date("1993-12-26T00:00:01Z"),
+    'glodap': new Date('0001-01-01T00:00:01Z')
   }
 
   return dates[dataset]

--- a/tests/tests/core/timeseries.tests.js
+++ b/tests/tests/core/timeseries.tests.js
@@ -63,9 +63,16 @@ $RefParser.dereference(rawspec, (err, schema) => {
     });
 
     describe("GET /timeseries/copernicussla", function () {
-      it("make sure mostrecent behaves as expected", async function () {
+      it("make sure mostrecent behaves as expected with a time window", async function () {
         const response = await request.get("/timeseries/copernicussla?id=-46.875_35.625&data=sla&startDate=1993-02-21T00:00:00Z&endDate=1993-03-28T00:00:00Z&mostrecent=3").set({'x-argokey': 'developer'});
         expect(response.body[0].data).to.eql([[0.19362857142857143, 0.15418571428571431, 0.08815714285714285]]) 
+      });
+    });
+
+    describe("GET /timeseries/ccmpwind", function () {
+      it("make sure mostrecent behaves as expected without a time window", async function () {
+        const response = await request.get("/timeseries/ccmpwind?id=0.125_0.125&data=uwnd&mostrecent=3").set({'x-argokey': 'developer'});
+        expect(response.body[0].data).to.eql([["NaN",-0.6804429513535329,"NaN"]]) 
       });
     });
 


### PR DESCRIPTION
caught this when testing on CCMP wind, the only dataset to have the same last-in-time record in test db as in prod.