### PR TITLE
disambiguate grid and timeseries tracking

### DIFF
--- a/nodejs-server/controllers/Grid.js
+++ b/nodejs-server/controllers/Grid.js
@@ -6,7 +6,7 @@ var helpers = require('../helpers/helpers')
 
 module.exports.findgrid = function findgrid (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data, presRange, gridName) {
 
-  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query, product: gridName})
 
   Grid.findgrid(res,gridName, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data, presRange)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
@@ -34,7 +34,7 @@ module.exports.findgridMeta = function findgridMeta (req, res, next, id) {
 
 module.exports.gridVocab = function gridVocab (req, res, next, gridName) {
   
-  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query, product: gridName})
   
   Grid.gridVocab(gridName)
     .then(function (response) {

--- a/nodejs-server/controllers/Timeseries.js
+++ b/nodejs-server/controllers/Timeseries.js
@@ -7,7 +7,7 @@ var helpers = require('../helpers/helpers')
 
 module.exports.findtimeseries = function findtimeseries (req, res, next, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data, timeseriesName) {
   
-  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query, product: timeseriesName})
 
   Timeseries.findtimeseries(res, timeseriesName, id, startDate, endDate, polygon, multipolygon, winding, center, radius, compression, mostrecent, data)
     .then(pipefittings => helpers.data_pipeline.bind(null, res)(pipefittings),
@@ -35,7 +35,7 @@ module.exports.findtimeseriesMeta = function findtimeseriesMeta (req, res, next,
 
 module.exports.timeseriesVocab = function timeseriesVocab (req, res, next, timeseriesName) {
   
-  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query})
+  apihits.apihits.create({metadata: req.openapi.openApiRoute, query: req.query, product: timeseriesName})
 
   Timeseries.timeseriesVocab(timeseriesName)
     .then(function (response) {

--- a/nodejs-server/models/apihits.js
+++ b/nodejs-server/models/apihits.js
@@ -3,7 +3,8 @@ const Schema = mongoose.Schema;
 
 const apihits = Schema({
 	metadata: {type: String, required: true},
-	query: {type:Schema.Types.Mixed, required: false}
+	query: {type:Schema.Types.Mixed, required: false},
+	product: {type: String, required: false},
 }, { timestamps: {createdAt: 'timestamp'} })
 
 module.exports = {}


### PR DESCRIPTION
objects that get lumped under a category route (grids and timeseries) end up looking literally like `/grids/{gridName}` in hit tracking; add a product key to disambiguate.