### PR TITLE
hotfix 231012

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -6,4 +6,5 @@ RUN mkdir /app/npmlogs && chown -R 1000660000 /app/npmlogs
 COPY nodejs-server/package.json .
 RUN npm install
 RUN apk update
+RUN chown -R 1000660000 /app/npmlogs/.npm
 


### PR DESCRIPTION
Node 20.8.0 containers started failing after the openshift update today, attempting to mitigate