### PR TITLE
put new items at end of stub

### DIFF
--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -203,11 +203,11 @@ exports.findArgo = function(res,id,startDate,endDate,polygon,multipolygon,windin
 
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
                 data.timestamp,
-                Array.from(sourceset)
+                Array.from(sourceset),
+                data['metadata']
               ]
           }
           let postprocess = helpers.post_xform(argo['argoMeta'], pp_params, search_result, res, stub)

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -107,10 +107,10 @@ exports.findArgoTrajectory = function(res, id,startDate,endDate,polygon,multipol
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
-                data.timestamp
+                data.timestamp,
+                data['metadata']
               ]
           }
 

--- a/nodejs-server/service/ArgoneService.js
+++ b/nodejs-server/service/ArgoneService.js
@@ -79,11 +79,11 @@ exports.findargone = function(res, id,forecastOrigin,forecastGeolocation,metadat
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'],
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
                 data.geolocation_forecast.coordinates[0], 
-                data.geolocation_forecast.coordinates[1]
+                data.geolocation_forecast.coordinates[1],
+                data['metadata']
               ]
           }
 

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -121,13 +121,13 @@ exports.findCCHDO = function(res,id,startDate,endDate,polygon,multipolygon,windi
 
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
                 data.timestamp,
                 Array.from(sourceset),
                 metadata[0].woce_lines,
-                metadata[0].cchdo_cruise_id
+                metadata[0].cchdo_cruise_id,
+                data['metadata']
               ]
           }
 

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -119,11 +119,11 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,w
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
                 data.timestamp,
-                metadata[0].wmo
+                metadata[0].wmo,
+                data['metadata']
               ]
           }
 

--- a/nodejs-server/service/ExtendedService.js
+++ b/nodejs-server/service/ExtendedService.js
@@ -97,9 +97,9 @@ exports.findExtended = function(res,id,startDate,endDate,polygon,multipolygon,wi
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data['timestamp'],
-                data['geolocation']
+                data['geolocation'],
+                data['metadata']
               ]
           }
           let postprocess = helpers.post_xform(Extended['extendedMeta'], pp_params, search_result, res, stub)

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -100,10 +100,10 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
-                data.timestamp
+                data.timestamp,
+                data['metadata']
               ]
           }
           let postprocess = helpers.post_xform(Grid[gridName+'Meta'], pp_params, search_result, res, stub)

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -88,10 +88,10 @@ exports.findTC = function(res,id,startDate,endDate,polygon,multipolygon,winding,
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
                 data.geolocation.coordinates[1], 
-                data.timestamp
+                data.timestamp,
+                data['metadata']
               ]
           }
 

--- a/nodejs-server/service/TimeseriesService.js
+++ b/nodejs-server/service/TimeseriesService.js
@@ -84,9 +84,9 @@ exports.findtimeseries = function(res,timeseriesName,id,startDate,endDate,polygo
               // should be id, long, lat, timestamp, and then anything needed to group this point together with other points in interesting ways.
               return [
                 data['_id'], 
-                data['metadata'],
                 data.geolocation.coordinates[0], 
-                data.geolocation.coordinates[1]
+                data.geolocation.coordinates[1],
+                data['metadata']
               ]
           }
           let postprocess = helpers.post_xform(Timeseries['timeseriesMeta'], pp_params, search_result, res, stub)

--- a/tests/tests/core/grid.tests.js
+++ b/tests/tests/core/grid.tests.js
@@ -174,7 +174,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /grids/rg09", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/grids/rg09?id=20040115000000_20.5_-64.5&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['20040115000000_20.5_-64.5', ["rg09_temperature_200401_Total","rg09_salinity_200401_Total"], 20.5, -64.5, "2004-01-15T00:00:00.000Z"]]);  
+        expect(response.body).to.eql([['20040115000000_20.5_-64.5', 20.5, -64.5, "2004-01-15T00:00:00.000Z", ["rg09_temperature_200401_Total","rg09_salinity_200401_Total"]]]);  
       });
     }); 
 

--- a/tests/tests/core/profiles.tests.js
+++ b/tests/tests/core/profiles.tests.js
@@ -150,7 +150,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /cchdo", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/cchdo?id=expo_08PD0196_1_sta_016_cast_001_type_ctd&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['expo_08PD0196_1_sta_016_cast_001_type_ctd', ["972_m1"], -57.6833, -42.8133, "1996-04-01T10:24:00.000Z", [ "cchdo_woce" ], [ "AR08" ], 972]]);  
+        expect(response.body).to.eql([['expo_08PD0196_1_sta_016_cast_001_type_ctd', -57.6833, -42.8133, "1996-04-01T10:24:00.000Z", [ "cchdo_woce" ], [ "AR08" ], 972,["972_m1"]]]);  
       });
     }); 
 
@@ -461,7 +461,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /argo", function () {
       it("minimal compression reponds appropriately", async function () {
         const response = await request.get("/argo?startDate=2022-07-07T12:00:21Z&endDate=2022-07-07T12:02:21Z&source=argo_bgc&compression=minimal").set({'x-argokey': 'developer'});
-         expect(response.body).to.eql([["2902857_003", ["2902857_m0"], 152.28354833333333, 42.39558666666667, "2022-07-07T12:01:21.000Z", ['argo_bgc', 'argo_core']]]) 
+         expect(response.body).to.eql([["2902857_003", 152.28354833333333, 42.39558666666667, "2022-07-07T12:01:21.000Z", ['argo_bgc', 'argo_core'].["2902857_m0"], ]]) 
       });
     });
     
@@ -531,7 +531,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /argo", function () {
       it("edgecase 20230315", async function () {
         const response = await request.get("/argo?id=2902857_001&presRange=80,100&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['2902857_001',["2902857_m0"],152.12710166666668,42.39075666666667,'2022-07-05T12:01:51.999Z',[ 'argo_bgc', 'argo_core' ]]]);
+        expect(response.body).to.eql([['2902857_001',152.12710166666668,42.39075666666667,'2022-07-05T12:01:51.999Z',[ 'argo_bgc', 'argo_core' ],["2902857_m0"],]]);
       });
     });
 

--- a/tests/tests/core/profiles.tests.js
+++ b/tests/tests/core/profiles.tests.js
@@ -461,7 +461,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /argo", function () {
       it("minimal compression reponds appropriately", async function () {
         const response = await request.get("/argo?startDate=2022-07-07T12:00:21Z&endDate=2022-07-07T12:02:21Z&source=argo_bgc&compression=minimal").set({'x-argokey': 'developer'});
-         expect(response.body).to.eql([["2902857_003", 152.28354833333333, 42.39558666666667, "2022-07-07T12:01:21.000Z", ['argo_bgc', 'argo_core'].["2902857_m0"], ]]) 
+         expect(response.body).to.eql([["2902857_003", 152.28354833333333, 42.39558666666667, "2022-07-07T12:01:21.000Z", ['argo_bgc', 'argo_core'],["2902857_m0"] ]]) 
       });
     });
     

--- a/tests/tests/core/tc.tests.js
+++ b/tests/tests/core/tc.tests.js
@@ -136,7 +136,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /tc", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/tc?id=AL011851_18510625000000&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['AL011851_18510625000000', ["AL011851"], -94.8, 28, "1851-06-25T00:00:00.000Z"]]);  
+        expect(response.body).to.eql([['AL011851_18510625000000', -94.8, 28, "1851-06-25T00:00:00.000Z",["AL011851"],]]);  
       });
     }); 
 

--- a/tests/tests/core/trajectories.tests.js
+++ b/tests/tests/core/trajectories.tests.js
@@ -106,7 +106,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /argotrajectories", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/argotrajectories?id=13857_116&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['13857_116', ["13857_m0"], -28.744391, 5.435884, "2001-01-09T17:35:31.000Z"]]);  
+        expect(response.body).to.eql([['13857_116', -28.744391, 5.435884, "2001-01-09T17:35:31.000Z",["13857_m0"],]]);  
       });
     }); 
 

--- a/tests/tests/miami/drifters.tests.js
+++ b/tests/tests/miami/drifters.tests.js
@@ -137,7 +137,7 @@ $RefParser.dereference(rawspec, (err, schema) => {
     describe("GET /drifters", function () {
       it("should return appropriate minimal representation of this measurement", async function () {
         const response = await request.get("/drifters?id=101143_0&compression=minimal").set({'x-argokey': 'developer'});
-        expect(response.body).to.eql([['101143_0', ["101143"], -17.74345, 14.74677, "2012-03-15T22:00:00.000Z",1300915]]);  
+        expect(response.body).to.eql([['101143_0',  -17.74345, 14.74677, "2012-03-15T22:00:00.000Z",1300915,["101143"]]]);  
       });
     }); 
 


### PR DESCRIPTION
thinking about #297 some more, we dont want to blow up every application that assumes a given order of info in the stub; put the new items at the end so previous indexes aren't wrecked.