### PR TITLE
modulate longitudes and latitudes for the user

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -45,7 +45,27 @@ module.exports.geoWeightedSum = function(terms){
 
 module.exports.validlonlat = function(shape){
     // shape: array of lon lat arrays, [[lon 0, lat 0], [lon 1, lat 1], [lon 2, lat 2]...]
-    // returns true if all longitudes are in -180 to 180 and all latitudes are in -90 to 90, as required by mongo's geojson representation.
+    // returns the same array normalizd to longitudes on [-180,180] and latitudes on [-90,90]
+
+    return shape.map(([longitude, latitude]) => {
+      long = longitude
+      while (long > 180){
+        long -= 360
+      }
+      while (long < -180){
+        long += 360
+      }
+
+      lat = latitude
+      while (lat > 90){
+        lat -= 180
+      }
+      while (lat < -90){
+        lat += 180
+      }
+
+      return [long, lat]
+    })
 
     return shape.every(point => point[0] >= -180 && point[0] <= 180 && point[1] >= -90 && point[1] <= 90)
 
@@ -69,9 +89,7 @@ module.exports.polygon_sanitation = function(poly,enforceWinding){
     return {"code": 400, "message": "Polygon region wasn't proper JSON; format should be [[lon,lat],[lon,lat],...]"};
   }
 
-  if(!module.exports.validlonlat(p)){
-    return {"code": 400, "message": "All lon, lat pairs must respect -180<=lon<=180 and -90<=lat<-90"}; 
-  }
+  p = module.exports.validlonlat(p)
 
   p = {
     "type": "Polygon",

--- a/tests/tests/helpers.tests.js
+++ b/tests/tests/helpers.tests.js
@@ -42,9 +42,23 @@ $RefParser.dereference(rawspec, (err, schema) => {
     }); 
 
     describe("validlonlat", function () {
-      it("flags an invalid longitude", async function () {
-        points = [[-185.2236986,70.1153552],[-183.9932299,56.4218209],[-155.5166674,56.7123646],[-154.1104174,69.8748184],[-185.2236986,70.1153552]]
-        expect(helpers.validlonlat(points)).to.be.false  
+      it("waives through valid longitude", async function () {
+        points = [[175,70],[177,56],[-155,56],[-154,69],[175,70]]
+        expect(helpers.validlonlat(points)).to.eql([[175,70],[177,56],[-155,56],[-154,69],[175,70]])
+      });
+    });
+
+    describe("validlonlat", function () {
+      it("modulates an invalid longitude", async function () {
+        points = [[-185,70],[-183,56],[-155,56],[-154,69],[-185,70]]
+        expect(helpers.validlonlat(points)).to.eql([[175,70],[177,56],[-155,56],[-154,69],[175,70]])
+      });
+    }); 
+
+    describe("validlonlat", function () {
+      it("modulates an invalid longitude from several rotations away", async function () {
+        points = [[-905,70],[-2703,56],[-155,56],[-154,69],[-905,70]]
+        expect(helpers.validlonlat(points)).to.eql([[175,70],[177,56],[-155,56],[-154,69],[175,70]])
       });
     }); 
 


### PR DESCRIPTION
rather than just kicking and screaming when the user doesn't respect mongo's lon/lat ranges for 2dsphere lookups, modulate for them. Allows cutting and pasting polygons from the frontend more robustly.