### PR TITLE
bugfix for minimal extended objects

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -448,7 +448,7 @@ module.exports.datatable_stream = function(model, params, local_filter, projecti
 
   if(projection){
     // drop documents with no data before they come out of the DB, and project out only the listed data document keys
-    aggPipeline.push({$match: {'data.0':{$exists:true}}})
+    aggPipeline.push({$match: {$or: [{'data.0':{$exists:true}}, {'raster.0':{$exists:true}}]}})
     project = {}
     for(let i=0;i<projection.length;i++){
       project[projection[i]] = 1
@@ -498,6 +498,7 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
   // returns chunk mutated into its final, user-facing form
   // or return false to drop this item from the stream
   // nothing to do if we're just passing meta docs through for a bulk metadata match
+
   if(pp_params.batchmeta){
     return chunk
   }
@@ -709,10 +710,8 @@ module.exports.postprocess_stream = function(chunk, metadata, pp_params, stub){
 
 module.exports.post_xform = function(metaModel, pp_params, search_result, res, stub){
   let nDocs = 0
-
   let postprocess = pp_params.suppress_meta ? 
     pipe(async chunk => {
-
       // munge the chunk and push it downstream if it isn't rejected.
       let doc = null
       if(!pp_params.mostrecent || nDocs < pp_params.mostrecent){
@@ -749,7 +748,7 @@ module.exports.post_xform = function(metaModel, pp_params, search_result, res, s
         }
       }
       return null
-    }, 16)  
+    }, 16)
 
   return postprocess
 }

--- a/tests/tests/core/arShapes.tests.js
+++ b/tests/tests/core/arShapes.tests.js
@@ -40,6 +40,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
         const response_nodl = await request.get("/extended/ar?box=[[-179,-55],[179,-54]]").set({'x-argokey': 'developer'});
         expect(response_nodl.body.length).to.eql(1); 
       });
+    });
+
+    describe("GET /extended/ar", function () {
+      it("check basic minimal stub response", async function () {
+        const response = await request.get("/extended/ar?id=2000.01.01.03.0_5&compression=minimal").set({'x-argokey': 'developer'});
+        expect(response.body.length).to.eql(1); 
+      });
     }); 
   }
 })


### PR DESCRIPTION
extended docs were getting mistakenly dropped when `compression=minimal` was set since they don't have a `data` attribute.