### PR TITLE
metafilter bugfix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.41
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.42
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -310,7 +310,7 @@ module.exports.datatable_stream = function(model, params, local_filter, projecti
   }
 
   /// construct filter for matching metadata docs if required; timeseries never filter on metadata docs
-  if(!isTimeseries && foreign_docs.length > 0 && foreign_docs[0]._id !== null){
+  if(!isTimeseries && params.metafilter){
     let metaIDs = new Set(foreign_docs.map(x => x['_id']))
     foreignMatch.push({$match:{'metadata':{$in:Array.from(metaIDs)}}})
   }

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -191,7 +191,7 @@ exports.findArgo = function(res,id,startDate,endDate,polygon,multipolygon,box,wi
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
     if(platform || platform_type){
         let match = {
             'platform': platform,
@@ -200,7 +200,7 @@ exports.findArgo = function(res,id,startDate,endDate,polygon,multipolygon,box,wi
         Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
         metafilter = argo['argoMeta'].aggregate([{$match: match}]).exec()
-        metacomplete = true
+        params.metafilter = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -105,10 +105,10 @@ exports.findArgoTrajectory = function(res, id,startDate,endDate,polygon,multipol
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
     if(platform){
         metafilter = trajectories['argotrajectoriesMeta'].aggregate([{$match: {'platform': platform}}]).exec()
-        metacomplete = true
+        params.metafilter = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/ArgoneService.js
+++ b/nodejs-server/service/ArgoneService.js
@@ -68,7 +68,7 @@ exports.findargone = function(res, id,forecastOrigin,forecastGeolocation,metadat
 
     // metadata table filter: no-op promise stub, nothing to filter grid data docs on from metadata at the moment
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, argone['argone'], {batchmeta:batchmeta}, local_filter, projection, null))

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -99,7 +99,7 @@ exports.findCCHDO = function(res,id,startDate,endDate,polygon,multipolygon,box,w
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
     if(woceline||cchdo_cruise){
         let match = {
             'woce_lines': woceline,
@@ -108,7 +108,7 @@ exports.findCCHDO = function(res,id,startDate,endDate,polygon,multipolygon,box,w
         Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
         metafilter = cchdo['cchdoMeta'].aggregate([{$match: match}]).exec()
-        metacomplete = true
+        params.metafilter = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -101,7 +101,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,b
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
     if(wmo||platform){
         let match = {
             'wmo': wmo,
@@ -110,7 +110,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,multipolygon,b
         Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
         metafilter = Drifter['drifterMeta'].aggregate([{$match: match}]).exec()
-        metacomplete = true
+        params.metafilter = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/EasyoceanService.js
+++ b/nodejs-server/service/EasyoceanService.js
@@ -112,6 +112,7 @@ exports.findeasyocean = function(res, id,startDate,endDate,polygon,multipolygon,
 
     // metadata table filter: no-op promise, nothing to filter easy ocean on in metadata atm
     let metafilter = Promise.resolve([])
+    params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, easyocean['easyocean'], params, local_filter, projection, data_filter))

--- a/nodejs-server/service/ExtendedService.js
+++ b/nodejs-server/service/ExtendedService.js
@@ -114,6 +114,7 @@ exports.findExtended = function(res,id,startDate,endDate,polygon,multipolygon,bo
 
     // metadata table filter: no-op promise stub, nothing to filter grid data docs on from metadata at the moment
     let metafilter = Promise.resolve([])
+    params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Extended[extendedName], params, local_filter, projection, null))

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -92,7 +92,7 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,multipolyg
 
     // metadata table filter: no-op promise stub, nothing to filter grid data docs on from metadata at the moment
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Grid[gridName], params, local_filter, projection, null))

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -75,10 +75,10 @@ exports.findTC = function(res,id,startDate,endDate,polygon,multipolygon,box,wind
 
     // metadata table filter: no-op promise if nothing to filter metadata for, custom search otherwise
     let metafilter = Promise.resolve([])
-    let metacomplete = false
+    params.metafilter = false
     if(name){
         metafilter = tc['tcMeta'].aggregate([{$match: {'name': name}}]).exec()
-        metacomplete = true
+        params.metafilter = true
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/TimeseriesService.js
+++ b/nodejs-server/service/TimeseriesService.js
@@ -75,6 +75,7 @@ exports.findtimeseries = function(res,timeseriesName,id,startDate,endDate,polygo
 
     // always fetch the metadata doc so we can pull the full list of timesteps off of it
     let metafilter = Timeseries['timeseriesMeta'].aggregate([{$match: {"_id": timeseriesName}}]).exec()
+    params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Timeseries[timeseriesName], params, local_filter, projection, null))

--- a/tests/tests/core/profiles.tests.js
+++ b/tests/tests/core/profiles.tests.js
@@ -474,21 +474,21 @@ $RefParser.dereference(rawspec, (err, schema) => {
 
     describe("GET /argo", function () {
       it("only gets one result", async function () {
-        const response = await request.get("/argo?platform=4901283&mostrecent=1").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?platform=2902857&mostrecent=1").set({'x-argokey': 'developer'});
          expect(response.body.length).to.eql(1);
       });
     });
 
     describe("GET /argo", function () {
       it("gets most recent 2 results", async function () {
-        const response = await request.get("/argo?platform=4901283&mostrecent=2").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?platform=2902857&mostrecent=2").set({'x-argokey': 'developer'});
          expect(response.body.length).to.eql(2);
       });
     });
 
     describe("GET /argo", function () {
       it("confirm mostrecent and data queries work together nicely", async function () {
-        const response = await request.get("/argo?platform=4901283&data=temperature_sfile&mostrecent=2").set({'x-argokey': 'developer'});
+        const response = await request.get("/argo?platform=2902857&data=temperature_sfile&mostrecent=2").set({'x-argokey': 'developer'});
          expect(response.body.length).to.eql(2);
       });
     });

--- a/tests/tests/core/tc.tests.js
+++ b/tests/tests/core/tc.tests.js
@@ -84,6 +84,13 @@ $RefParser.dereference(rawspec, (err, schema) => {
       });
     });    
 
+    describe("GET /tc?startDate&endDate", function () {
+      it("same as last test, but ensure metafilter is dropping profiles without matching metadata", async function () {
+        const response = await request.get("/tc?startDate=1851-06-24T23:00:00Z&endDate=1851-06-25T01:00:00Z&data=wind&name=pixel").set({'x-argokey': 'developer'});
+        expect(response.body).to.be.jsonSchema(schema.paths['/tc'].get.responses['200'].content['application/json'].schema);   
+      });
+    });  
+
     describe("GET /tc?name", function () {
       it("should be 4 records for the DEMO TC", async function () {
         const response = await request.get("/tc?name=DEMO").set({'x-argokey': 'developer'});


### PR DESCRIPTION
In response to https://github.com/argovis/argovis_helpers/issues/31. Turns out that if a filter on metadata returned no results, the API just drops the metafilter entirely as if the user didn't add that constraint, which is not correct.