### PR TITLE
summary key selection

### DIFF
--- a/core-spec.json
+++ b/core-spec.json
@@ -1837,6 +1837,14 @@
             "parameters": [
                {
                   "$ref": "#/components/parameters/genericID"
+               },
+               {
+                  "in": "query",
+                  "name": "key",
+                  "description": "If set, return only the named key from the summary document (intended for getting back just jsonld, for example)",
+                  "schema": {
+                     "type": "string"
+                  }
                }
             ],
             "responses": {

--- a/miami-spec.json
+++ b/miami-spec.json
@@ -270,6 +270,14 @@
             "parameters": [
                {
                   "$ref": "#/components/parameters/genericID"
+               },
+               {
+                  "in": "query",
+                  "name": "key",
+                  "description": "If set, return only the named key from the summary document (intended for getting back just jsonld, for example)",
+                  "schema": {
+                     "type": "string"
+                  }
                }
             ],
             "responses": {

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -2703,6 +2703,15 @@ paths:
         schema:
           type: string
           example: 4902911_0
+      - name: key
+        in: query
+        description: "If set, return only the named key from the summary document\
+          \ (intended for getting back just jsonld, for example)"
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK

--- a/nodejs-server/api/openapi.miami.yaml
+++ b/nodejs-server/api/openapi.miami.yaml
@@ -378,6 +378,15 @@ paths:
         schema:
           type: string
           example: 4902911_0
+      - name: key
+        in: query
+        description: "If set, return only the named key from the summary document\
+          \ (intended for getting back just jsonld, for example)"
+        required: false
+        style: form
+        explode: true
+        schema:
+          type: string
       responses:
         "200":
           description: OK

--- a/nodejs-server/controllers/SummaryExperimental.js
+++ b/nodejs-server/controllers/SummaryExperimental.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var SummaryExperimental = require('../service/SummaryExperimentalService');
 
-module.exports.fetchSummary = function fetchSummary (req, res, next, id) {
-  SummaryExperimental.fetchSummary(id)
+module.exports.fetchSummary = function fetchSummary (req, res, next, id, key) {
+  SummaryExperimental.fetchSummary(id, key)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/service/SummaryExperimentalService.js
+++ b/nodejs-server/service/SummaryExperimentalService.js
@@ -5,9 +5,10 @@
  * Fetch a document from the summary collection by ID.
  *
  * id String Unique ID to search for. (optional)
+ * key String If set, return only the named key from the summary document (intended for getting back just jsonld, for example) (optional)
  * returns Object
  **/
-exports.fetchSummary = function(id) {
+exports.fetchSummary = function(id,key) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = { };

--- a/nodejs-server/service/SummaryExperimentalService.js
+++ b/nodejs-server/service/SummaryExperimentalService.js
@@ -12,6 +12,20 @@ const helpers = require('../helpers/helpers')
 exports.fetchSummary = function(id,key) {
   return new Promise(function(resolve, reject) {
     const query = summaries.find({"_id":id}).lean()
-    query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
+
+    let f = function(k, d){
+      if(k in d[0]){
+        return d[0][k]
+      } else {
+        return d
+      }
+    }
+
+    if(key){
+      query.exec(helpers.queryCallback.bind(null,f.bind(null, key), resolve, reject))
+    } else {
+      query.exec(helpers.queryCallback.bind(null,null, resolve, reject))
+    }
   });
 }
+


### PR DESCRIPTION
allow a `key` option in `/summary` to pick out and return only a single key from the selected document - good for getting clean jsonld.