### PR TITLE
only coerce timestamps onto costing, not search filter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.43
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.44
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -171,14 +171,10 @@ module.exports.parameter_sanitization = function(dataset,id,startDate,endDate,po
 
   if(startDate){
     params.startDate = new Date(startDate);
-  } else {
-    params.startDate = module.exports.earliest_records(dataset)
   }
 
   if(endDate){
     params.endDate = new Date(endDate);
-  } else {
-    params.endDate = module.exports.final_records(dataset)
   }
 
   if(polygon){
@@ -888,6 +884,13 @@ module.exports.cost = function(url, c, cellprice, metaDiscount, maxbulk, maxbulk
         let params = module.exports.parameter_sanitization(path[path.length-1], null,qString.get('startDate'),qString.get('endDate'),qString.get('polygon'),qString.get('box'),false,qString.get('center'),qString.get('radius'), true)
         if(params.hasOwnProperty('code')){
           return params
+        }
+        // request costs infer a startDate and endDate if not provided
+        if(!(params.hasOwnProperty('startDate'))){
+          params.startDate = module.exports.earliest_records(params['dataset'])
+        }
+        if(!(params.hasOwnProperty('endDate'))){
+          params.endDate = module.exports.final_records(params['dataset'])
         }
 
         ///// cost out request; timeseries limited only by geography since entire time span for each matched lat/long must be pulled off disk in any case.

--- a/nodejs-server/models/drifter.js
+++ b/nodejs-server/models/drifter.js
@@ -54,5 +54,5 @@ const DrifterMetaSchema = Schema({
 });
 
 module.exports = {}
-module.exports.drifterMeta = mongoose.model('drifterMetax', DrifterMetaSchema, 'drifterMetax');
-module.exports.drifter = mongoose.model('drifterx', DrifterSchema, 'drifterx');
+module.exports.drifterMeta = mongoose.model('drifterMeta', DrifterMetaSchema, 'drifterMeta');
+module.exports.drifter = mongoose.model('drifter', DrifterSchema, 'drifter');


### PR DESCRIPTION
caused awkward edge case where an Argo profile mislabeled as coming from the future were suppressed from search results.