### PR TITLE
detecting time bounds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.45
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.46
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.46
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.45
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/nodejs-server/models/drifter.js
+++ b/nodejs-server/models/drifter.js
@@ -54,5 +54,5 @@ const DrifterMetaSchema = Schema({
 });
 
 module.exports = {}
-module.exports.drifterMeta = mongoose.model('drifterMeta', DrifterMetaSchema, 'drifterMeta');
-module.exports.drifter = mongoose.model('drifter', DrifterSchema, 'drifter');
+module.exports.driftersMeta = mongoose.model('driftersMeta', DrifterMetaSchema, 'driftersMeta');
+module.exports.drifters = mongoose.model('drifters', DrifterSchema, 'drifters');

--- a/nodejs-server/models/trajectories.js
+++ b/nodejs-server/models/trajectories.js
@@ -59,5 +59,5 @@ const argotrajectoriesMetaSchema = Schema({
 });
 
 module.exports = {}
-module.exports.argotrajectoriesMeta = mongoose.model('trajectoriesMeta', argotrajectoriesMetaSchema, 'trajectoriesMeta');
-module.exports.argotrajectories = mongoose.model('trajectories', argotrajectoriesSchema, 'trajectories');
+module.exports.argotrajectoriesMeta = mongoose.model('argotrajectoriesMeta', argotrajectoriesMetaSchema, 'argotrajectoriesMeta');
+module.exports.argotrajectories = mongoose.model('argotrajectories', argotrajectoriesSchema, 'argotrajectories');

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -53,7 +53,7 @@ exports.argotrajectoryVocab = function(parameter) {
 exports.findArgoTrajectory = function(res,id,startDate,endDate,polygon,box,center,radius,metadata,platform,compression,data,batchmeta) {
   return new Promise(function(resolve, reject) {
     // input sanitization
-    let params = helpers.parameter_sanitization('trajectories',id,startDate,endDate,polygon,box,false,center,radius)
+    let params = helpers.parameter_sanitization('argotrajectories',id,startDate,endDate,polygon,box,false,center,radius)
     if(params.hasOwnProperty('code')){
       // error, return and bail out
       reject(params)

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -61,7 +61,7 @@ exports.findArgoTrajectory = function(res,id,startDate,endDate,polygon,box,cente
     }
     params.batchmeta = batchmeta
     params.compression = compression
-    params.metacollection = 'trajectoriesMeta'
+    params.metacollection = 'argotrajectoriesMeta'
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -21,7 +21,7 @@ exports.drifterMetaSearch = function(res,id,platform,wmo) {
     }
     Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
-    const query = Drifter['drifterMeta'].aggregate([{$match:match}]);
+    const query = Drifter['driftersMeta'].aggregate([{$match:match}]);
     let postprocess = helpers.meta_xform(res)
     res.status(404) // 404 by default
     resolve([query.cursor(), postprocess])
@@ -58,7 +58,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,box,center,rad
     }
     params.batchmeta = batchmeta
     params.compression = compression
-    params.metacollection = 'drifterMeta'
+    params.metacollection = 'driftersMeta'
     params.archtypical_meta = true // any metadata document passed in to the datafilter from the metafilter has a globally applicable data_info, and possibly other fields.
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))
@@ -102,15 +102,15 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,box,center,rad
         }
         Object.keys(match).forEach((k) => match[k] === undefined && delete match[k]);
 
-        metafilter = Drifter['drifterMeta'].aggregate([{$match: match}]).exec()
+        metafilter = Drifter['driftersMeta'].aggregate([{$match: match}]).exec()
         params.metafilter = true
     } else {
-      metafilter = Drifter['drifterMeta'].find({}).limit(1).exec()
+      metafilter = Drifter['driftersMeta'].find({}).limit(1).exec()
       params.metafilter = false
     }
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection
-    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Drifter['drifter'], params, local_filter))
+    let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Drifter['drifters'], params, local_filter))
 
     Promise.all([metafilter, datafilter])
         .then(search_result => {
@@ -171,7 +171,7 @@ exports.drifterVocab = function(parameter) {
       ])
       return
     } else if(parameter == 'metadata'){
-      Drifter['drifter'].find().distinct('metadata', function (err, vocab) {
+      Drifter['drifters'].find().distinct('metadata', function (err, vocab) {
         if (err){
           reject({"code": 500, "message": "Server error"});
           return;
@@ -185,7 +185,7 @@ exports.drifterVocab = function(parameter) {
             'platform': 'platform'
         }
 
-        Drifter['drifterMeta'].find().distinct(lookup[parameter], function (err, vocab) {
+        Drifter['driftersMeta'].find().distinct(lookup[parameter], function (err, vocab) {
           if (err){
             reject({"code": 500, "message": "Server error"});
             return;


### PR DESCRIPTION
 - use the summaries.ratelimiter document to find earliest and latest collection times, without hard-coding them in the api
 - standardize collection names for drifters and argotrajectories
 - also autodetect and simplify discount data routes