### PR TITLE
verticalRange for ts, on-disk sorting

### DIFF
--- a/core-spec.json
+++ b/core-spec.json
@@ -613,6 +613,9 @@
                   "$ref": "#/components/parameters/radius"
                },
                {
+                "$ref": "#/components/parameters/verticalRange"
+               },
+               {
                   "$ref": "#/components/parameters/compression"
                },
                {

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -907,6 +907,21 @@ paths:
         schema:
           type: number
           example: 50
+      - name: verticalRange
+        in: query
+        description: Vertical range to filter for in pressure or depth as appropriate
+          for this dataset; levels outside this range will not be returned.
+        required: false
+        style: form
+        explode: false
+        allowReserved: true
+        schema:
+          type: array
+          example: "10,20.1"
+          items:
+            maxItems: 2
+            minItems: 2
+            type: number
       - name: compression
         in: query
         description: Data minification strategy to apply.

--- a/nodejs-server/controllers/Timeseries.js
+++ b/nodejs-server/controllers/Timeseries.js
@@ -3,8 +3,8 @@
 var utils = require('../utils/writer.js');
 var Timeseries = require('../service/TimeseriesService');
 
-module.exports.findtimeseries = function findtimeseries (req, res, next, timeseriesName, id, startDate, endDate, polygon, box, center, radius, compression, data, batchmeta) {
-  Timeseries.findtimeseries(timeseriesName, id, startDate, endDate, polygon, box, center, radius, compression, data, batchmeta)
+module.exports.findtimeseries = function findtimeseries (req, res, next, timeseriesName, id, startDate, endDate, polygon, box, center, radius, verticalRange, compression, data, batchmeta) {
+  Timeseries.findtimeseries(timeseriesName, id, startDate, endDate, polygon, box, center, radius, verticalRange, compression, data, batchmeta)
     .then(function (response) {
       utils.writeJson(res, response);
     })

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -366,7 +366,7 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
     aggPipeline.push({$project: junk})
   }
 
-  return model.aggregate(aggPipeline).cursor()  
+  return model.aggregate(aggPipeline, { allowDiskUse: true }).cursor()  
 }
 
 module.exports.parse_data_qsp = function(data_query){

--- a/nodejs-server/service/TimeseriesService.js
+++ b/nodejs-server/service/TimeseriesService.js
@@ -12,12 +12,13 @@
  * box String lon, lat pairs of the lower left and upper right corners of a box on a mercator projection, packed like [[lower left lon, lower left lat],[upper right lon, upper right lat]] (optional)
  * center List center to measure max radius from when defining circular region of interest; must be used in conjunction with query string parameter 'radius'. (optional)
  * radius BigDecimal km from centerpoint when defining circular region of interest; must be used in conjunction with query string parameter 'center'. (optional)
+ * verticalRange List Vertical range to filter for in pressure or depth as appropriate for this dataset; levels outside this range will not be returned. (optional)
  * compression String Data minification strategy to apply. (optional)
  * data List Keys of data to include. Return only documents that have all data requested, within the pressure range if specified. Accepts ~ negation to filter out documents including the specified data. Omission of this parameter will result in metadata only responses. (optional)
  * batchmeta String return the metadata documents corresponding to a temporospatial data search (optional)
  * returns List
  **/
-exports.findtimeseries = function(timeseriesName,id,startDate,endDate,polygon,box,center,radius,compression,data,batchmeta) {
+exports.findtimeseries = function(timeseriesName,id,startDate,endDate,polygon,box,center,radius,verticalRange,compression,data,batchmeta) {
   return new Promise(function(resolve, reject) {
     var examples = {};
     examples['application/json'] = [ {


### PR DESCRIPTION
Allow a verticalRange qsp for timeseries, to match BSOSE rust API. no-op here for now.