### PR TITLE
relax limits on timeseries requests

### DIFF
--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -273,8 +273,8 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
   // set up first part of pipeline aggregation:
   let aggPipeline = proxMatch.concat(spacetimeMatch).concat(local_filter).concat(foreignMatch)
 
-  if(params.compression !== 'minimal'){
-    // some stub requests are allowed that would swamp mongo's default sorting limits.
+  if(params.compression !== 'minimal' && params.is_timeseries === false){
+    // some stub and timeseries requests are allowed that would swamp mongo's default sorting limits.
     aggPipeline.push({$sort: {'timestamp':-1}})
   }
 
@@ -366,7 +366,7 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
     aggPipeline.push({$project: junk})
   }
 
-  return model.aggregate(aggPipeline, { allowDiskUse: true }).cursor()  
+  return model.aggregate(aggPipeline).cursor()  
 }
 
 module.exports.parse_data_qsp = function(data_query){

--- a/nodejs-server/middleware/ratelimiter/tokenbucket.js
+++ b/nodejs-server/middleware/ratelimiter/tokenbucket.js
@@ -37,7 +37,7 @@ module.exports.tokenbucket = function (req, res, next) {
 	let cellprice = 0.0001 // token cost of 1 sq deg day
 	let metaDiscount = 100 // scaledown factor to discount except-data-values request by relative to data requests
 	let maxbulk = 2000000 // maximum allowed size of ndays x area[sq km]/13000sqkm; set to prevent OOM crashes
-	let maxbulk_timeseries = 50 // maximum allowed size of area[sq km]/13000sqkm for timeseries; set to prevent OOM crashes
+	let maxbulk_timeseries = 225 // maximum allowed size of area[sq km]/13000sqkm for timeseries; set to prevent OOM crashes
 	let argokey = 'guest'
 	if(req.headers['x-argokey']){
 		argokey = req.headers['x-argokey']


### PR DESCRIPTION
Donata correctly pointed out that there's no need to sort timeseries documents by timestamp, and therefore no need to sort on disk or be squeamish about allowing somewhat larger requests. Trying 15x15 degree limits.