### PR TITLE
allow localGPspace as a new grid route

### DIFF
--- a/core-spec.json
+++ b/core-spec.json
@@ -404,7 +404,7 @@
                   "required": "true",
                   "schema": {
                      "type": "string",
-                     "enum": ["rg09", "kg21", "glodap"]
+                     "enum": ["rg09", "kg21", "localGPspace", "glodap"]
                   }
                },
                {
@@ -534,7 +534,7 @@
                   "required": "true",
                   "schema": {
                      "type": "string",
-                     "enum": ["rg09", "kg21", "glodap"]
+                     "enum": ["rg09", "kg21", "localGPspace", "glodap"]
                   }
                },
                {

--- a/nodejs-server/api/openapi.core.yaml
+++ b/nodejs-server/api/openapi.core.yaml
@@ -530,6 +530,7 @@ paths:
           enum:
           - rg09
           - kg21
+          - localGPspace
           - glodap
       - name: id
         in: query
@@ -767,6 +768,7 @@ paths:
           enum:
           - rg09
           - kg21
+          - localGPspace
           - glodap
       - name: parameter
         in: query


### PR DESCRIPTION
and allow kg21 to alias in. replaces #377 targeting the actually correct branch.