### PR TITLE
archtypical_meta -> genericMeta

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.48
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.49
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -765,7 +765,7 @@ module.exports.postprocess_stream = function(chunk, metadata, params, stub, res)
       }
     }
     if(newmeta.length > 0){
-      return newmeta
+      return newmeta.filter(x => !x._id.includes('GenericMeta'))
     }
   } else {
     if(chunk.metadata_docs){

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -327,13 +327,21 @@ module.exports.datatable_stream = function(model, params, local_filter, foreign_
   }
 
   //// some metadata documents pre-pulled have globally useful data
-  if(params.archtypical_meta && foreign_docs.length > 0){
-    if(params.data_query){
+  if(params.genericMeta && foreign_docs.length > 0){
+    if(params.data_query || params.verticalRange || params.presRange){
       aggPipeline.push({
         $addFields: {
           data_info: foreign_docs[0].data_info
         }
       })
+    }
+
+    if(params.is_grid && params.verticalRange || params.presRange){
+        aggPipeline.push({
+            $addFields: {
+                levels: foreign_docs[0].levels
+            }
+        })
     }
 
     if(params.is_timeseries){

--- a/nodejs-server/service/ArgoService.js
+++ b/nodejs-server/service/ArgoService.js
@@ -141,8 +141,6 @@ function collectionSearch(collection, datamodel, metamodel, res,id,startDate,end
           reject(params)
           return
         }
-        params.batchmeta = batchmeta
-        params.compression = compression
         params.verticalRange = presRange || verticalRange
         params.metacollection = collection+'Meta'
         if(data && data.join(',') !== 'except-data-values'){

--- a/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
+++ b/nodejs-server/service/ArgoTrajectoriesExperimentalService.js
@@ -59,8 +59,7 @@ exports.findArgoTrajectory = function(res,id,startDate,endDate,polygon,box,cente
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     params.metacollection = 'argotrajectoriesMeta'
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))

--- a/nodejs-server/service/ArgoneService.js
+++ b/nodejs-server/service/ArgoneService.js
@@ -51,7 +51,7 @@ exports.findargone = function(res, id,forecastOrigin,forecastGeolocation,metadat
     }
 
     // metadata table filter: just get the sole solitary argon metadata doc
-    let metafilter = argone['argoneMeta'].find({_id:'argone'}).exec()
+    let metafilter = argone['argoneMeta'].find({_id:'argone'}).lean().exec()
     let params = {
       'metafilter': false,
       'batchmeta': batchmeta,
@@ -64,7 +64,7 @@ exports.findargone = function(res, id,forecastOrigin,forecastGeolocation,metadat
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
     params.lookup_meta = false
-    params.archtypical_meta = true // there's just the one.
+    params.genericMeta = true // the sole metadata doc counts as effectively generic.
 
     // can we afford to project data documents down to a subset in aggregation?
     if(compression=='minimal' && data==null){

--- a/nodejs-server/service/CchdoService.js
+++ b/nodejs-server/service/CchdoService.js
@@ -35,8 +35,7 @@ exports.findCCHDO = function(res,id,startDate,endDate,polygon,box,center,radius,
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     params.verticalRange = presRange || verticalRange
     params.metacollection = 'cchdoMeta'
     if(data && data.join(',') !== 'except-data-values'){

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -56,8 +56,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,box,center,rad
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     params.metacollection = 'driftersMeta'
     params.genericMeta = true // the summaries collection has a generic metadata document that applies to all data docs in the corresponding data collection.
     if(data && data.join(',') !== 'except-data-values'){

--- a/nodejs-server/service/DriftersService.js
+++ b/nodejs-server/service/DriftersService.js
@@ -59,7 +59,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,box,center,rad
     params.batchmeta = batchmeta
     params.compression = compression
     params.metacollection = 'driftersMeta'
-    params.archtypical_meta = true // any metadata document passed in to the datafilter from the metafilter has a globally applicable data_info, and possibly other fields.
+    params.genericMeta = true // the summaries collection has a generic metadata document that applies to all data docs in the corresponding data collection.
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
@@ -105,7 +105,7 @@ exports.drifterSearch = function(res,id,startDate,endDate,polygon,box,center,rad
         metafilter = Drifter['driftersMeta'].aggregate([{$match: match}]).exec()
         params.metafilter = true
     } else {
-      metafilter = Drifter['driftersMeta'].find({}).limit(1).exec()
+      metafilter = summaries.find({_id:'driftersGenericMeta'}).lean().exec()
       params.metafilter = false
     }
 

--- a/nodejs-server/service/EasyoceanService.js
+++ b/nodejs-server/service/EasyoceanService.js
@@ -56,8 +56,7 @@ exports.findeasyocean = function(res,id,startDate,endDate,polygon,box,center,rad
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     params.metacollection = 'easyoceanMeta'
     params.verticalRange = presRange || verticalRange
     if(data && data.join(',') !== 'except-data-values'){

--- a/nodejs-server/service/ExtendedService.js
+++ b/nodejs-server/service/ExtendedService.js
@@ -80,8 +80,7 @@ exports.findExtended = function(res,extendedName,id,startDate,endDate,polygon,bo
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
     params.lookup_meta = false // there's only one AR meta document, just look it up once
-    params.archtypical_meta = params.data_query
-
+    params.genericMeta = true // the sole AR meta doc counts as a generic metadata doc.
     // decide y/n whether to service this request
     let bailout = helpers.request_sanitation(params.polygon, params.center, params.radius, null, false, null, null) 
     if(bailout){

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -55,8 +55,7 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,box,center
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     if(gridName === 'localGPintegral'){
         params.metacollection = 'localGPMeta'
         verticalRange = null // not obvious how to filter integral ranges by vertical bounds, decline for now.
@@ -113,7 +112,6 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,box,center
     let datafilter = metafilter.then(helpers.datatable_stream.bind(null, Grid[gridName], params, local_filter))
     Promise.all([metafilter, datafilter])
         .then(search_result => {
-
           let stub = function(data){
               // given a data and corresponding metadata document,
               // return the record that should be returned when the compression=minimal API flag is set

--- a/nodejs-server/service/GridService.js
+++ b/nodejs-server/service/GridService.js
@@ -65,11 +65,12 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,box,center
         params.metacollection = gridName+'Meta'
     }
     params.is_grid = true
+    params.genericMeta = true // the summaries collection has a generic metadata document that applies to all data docs in a given grid collection
     params.verticalRange = presRange || verticalRange
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
-    params.lookup_meta = batchmeta || params.data_query || params.verticalRange
+    params.lookup_meta = batchmeta
     params.compression = compression
     params.batchmeta = batchmeta
     // decide y/n whether to service this request
@@ -96,8 +97,16 @@ exports.findgrid = function(res,gridName,id,startDate,endDate,polygon,box,center
       params.projection = ['_id', 'metadata', 'geolocation', 'timestamp']
     }
 
-    // metadata table filter: no-op promise stub, nothing to filter grid data docs on from metadata at the moment
+    // metadata table filter: nothing to filter on in meta collection, use this to fetch a generic metadata doc
+    // some grids have exactly one metadata doc, others have a summarized generic metadata doc.
     let metafilter = Promise.resolve([])
+    if(gridName === 'glodap'){
+        metafilter = Grid['glodapMeta'].find({_id:'glodapv2.2016b'}).lean().exec()
+    } else if(gridName === 'localGPintegral'){
+        metafilter = Grid['localGPMeta'].find({_id:'localGPintegral'}).lean().exec()
+    } else {
+        metafilter = summaries.find({_id:gridName+'GenericMeta'}).lean().exec()
+    }
     params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -37,7 +37,7 @@ exports.findTC = function(res,id,startDate,endDate,polygon,box,center,radius,nam
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
     params.lookup_meta = batchmeta 
-    params.archtypical_meta = params.data_query
+    params.genericMeta = true
     params.compression = compression
     params.batchmeta = batchmeta
 
@@ -72,8 +72,7 @@ exports.findTC = function(res,id,startDate,endDate,polygon,box,center,radius,nam
       metafilter = tc['tcMeta'].aggregate([{$match: {'name': name}}]).exec()
       params.metafilter = true
     } else if(!batchmeta) {
-      // get an arbitrary metadata doc, unless we're getting specific ones from batchmeta
-      metafilter = tc['tcMeta'].find({}).limit(1).exec()
+      metafilter = summaries.find({_id:'tcGenericMeta'}).lean().exec()
       params.metafilter = false
     }
 

--- a/nodejs-server/service/TcService.js
+++ b/nodejs-server/service/TcService.js
@@ -30,8 +30,7 @@ exports.findTC = function(res,id,startDate,endDate,polygon,box,center,radius,nam
       reject(params)
       return
     }
-    params.batchmeta = batchmeta
-    params.compression = compression
+
     params.metacollection = 'tcMeta'
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))

--- a/nodejs-server/service/TimeseriesService.js
+++ b/nodejs-server/service/TimeseriesService.js
@@ -36,7 +36,7 @@ exports.findtimeseries = function(res,timeseriesName,id,startDate,endDate,polygo
     params.batchmeta = batchmeta
     params.compression = compression
     params.is_timeseries = true
-    params.archtypical_meta = true // any metadata document passed in to the datafilter from the metafilter has a globally applicable data_info, and possibly other fields.
+    params.genericMeta = true // each timeseries collection has exactly one meta doc, which counts as generic.
     if(data && data.join(',') !== 'except-data-values'){
       params.data_query = helpers.parse_data_qsp(data.join(','))
     }
@@ -69,7 +69,7 @@ exports.findtimeseries = function(res,timeseriesName,id,startDate,endDate,polygo
     }
 
     // always fetch the metadata doc so we can pull the full list of timesteps off of it
-    let metafilter = Timeseries['timeseriesMeta'].aggregate([{$match: {"_id": timeseriesName}}]).exec()
+    let metafilter = Timeseries['timeseriesMeta'].find({"_id": timeseriesName}).lean().exec()
     params.metafilter = false
 
     // datafilter must run syncronously after metafilter in case metadata info is the only search parameter for the data collection

--- a/nodejs-server/service/TimeseriesService.js
+++ b/nodejs-server/service/TimeseriesService.js
@@ -33,8 +33,6 @@ exports.findtimeseries = function(res,timeseriesName,id,startDate,endDate,polygo
       return
     }
 
-    params.batchmeta = batchmeta
-    params.compression = compression
     params.is_timeseries = true
     params.genericMeta = true // each timeseries collection has exactly one meta doc, which counts as generic.
     if(data && data.join(',') !== 'except-data-values'){


### PR DESCRIPTION
There are many cases where a given query will need to copy a particular key from the metadata documents onto the corresponding data documents, but the meta key is unchanging over the entire collection (`data_info` and a grid's `levels` or a timeseries' `timeseries` meta properties are prominent examples).

Previously for some cases, we used the `archtypical_meta` flag to indicate that the data query could fetch an arbitrary metadata document and assume given properties therein were valid for all data docs in the collection. This runs into problems in for example the RG grid, where levels and data_info are in fact generic, but metadata docs are split over temperature and salinity upstream files, precluding simple arbitrary choices. Prior to now, this would trigger a lookup aggregation stage which would look up the meta doc for every data doc in a query, which could generate a significant performance hit.

To address all cases, we drop the `archtypical_meta` flag in favor of a `genericMeta` flag, which indicates that certain metadata properties can be treated as universal for the collection; a document containing these properties will either be:
 - the sole metadata document corresponding to every data doc in the collection (for example as seen in every current timeseries collection)
 - or, a specially constructed generic metadata document in the `summaries` collections, IDed as `<collection name>GenericMeta`.

The following PRs inject generic metadata summaries as part of this effort:
- https://github.com/argovis/drifter-sync/pull/11
- https://github.com/argovis/tc-sync/pull/9
- https://github.com/argovis/grid-sync/pull/25