### PR TITLE
Server timeseries bugfix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: 'create network'
         run: docker network create ghactions
       - name: 'launch db'
-        run: docker container run -d --network ghactions --name database argovis/testdb:0.49
+        run: docker container run -d --network ghactions --name database argovis/testdb:0.50
       - name: 'launch redis'
         run: docker container run -d --network ghactions --name redis redis:7.0.2
       - name: 'build_api_rc'

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -713,8 +713,8 @@ module.exports.postprocess_stream = function(chunk, metadata, params, stub, res)
     chunk.data = module.exports.data_filter(data_mask, chunk.data, params.data_query)
     chunk.data_info = module.exports.data_info_filter(data_mask, chunk.data_info)
     //// filter off levels that have all null values for all requested variables
-    //// skip this for grids, they need to be rectangular
-    if(!params.data_query[1].includes('all') && !params.is_grid){
+    //// skip this for grids and timeseries, they need to be rectangular
+    if(!params.data_query[1].includes('all') && !params.is_grid && !params.is_timeseries){
       chunk.data = module.exports.level_filter(chunk.data, chunk.data_info, params.coerced_pressure)
     }
     //// dump pressure if coerced and it's the only thing left on the data array after masking

--- a/nodejs-server/helpers/helpers.js
+++ b/nodejs-server/helpers/helpers.js
@@ -622,7 +622,7 @@ module.exports.level_filter = function(data, data_info, coerced_pressure){
   });
 
   dcopy = dcopy.map( (level,index) => {
-    if(level.every(x => x === null)){
+    if(level.every(x => x === null || x === 'null')){ // string case is just there to exercise the tests, but shouldn't happen in practice
       return index
     } else{
       return -1

--- a/tests/tests/core/timeseries.tests.js
+++ b/tests/tests/core/timeseries.tests.js
@@ -37,6 +37,13 @@ describe("GET /timeseries/copernicussla", function () {
   });
 });
 
+describe("GET /timeseries/copernicussla", function () {
+    it("nulls should not drop from timeseries data vectors", async function () {
+      const response = await request.get("/timeseries/copernicussla?center=-46.875,35.625&radius=1&startDate=2022-07-10T00:00:00Z&endDate=2022-07-31T00:00:00Z&data=sla").set({'x-argokey': 'developer'});
+      expect(response.body[0].data[0].length).to.eql(response.body[0].timeseries.length)        
+    });
+  });
+
 describe("GET /timeseries/ccmpwind", function () {
   it("make sure ccmp time slicing matches expectations", async function () {
     const response = await request.get("/timeseries/ccmpwind?center=0.125,0.125&radius=1&startDate=1993-01-30T00:00:00Z&endDate=1993-02-14T00:00:00Z&data=uwnd").set({'x-argokey': 'developer'});


### PR DESCRIPTION
Like grids, timeseries need to not delete levels even if all the data values are null at that level, since the data vectors need to line up with the timeseries vector.